### PR TITLE
Compilation fails with extract-text-webpack-plugin

### DIFF
--- a/spec/HtmlWebpackPluginSpec.js
+++ b/spec/HtmlWebpackPluginSpec.js
@@ -356,6 +356,28 @@ describe('HtmlWebpackPlugin', function () {
     }, ['<link href="styles.css"'], null, done);
   });
 
+  it('should work with the css extract plugin while using a JavaScript template', function (done) {
+    var ExtractTextPlugin = require('extract-text-webpack-plugin');
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/dynamic-template/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: ExtractTextPlugin.extract('style-loader', 'css-loader') }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          template: path.join(__dirname, 'fixtures/dynamic-template/index.html.js')
+        }),
+        new ExtractTextPlugin('styles.css')
+      ]
+    }, ['<link href="styles.css"'], null, done);
+  });
+
   it('should allow to add cache hashes to with the css assets', function (done) {
     var ExtractTextPlugin = require('extract-text-webpack-plugin');
     testHtmlPlugin({

--- a/spec/fixtures/dynamic-template/component.css
+++ b/spec/fixtures/dynamic-template/component.css
@@ -1,0 +1,3 @@
+h1 {
+  color: pink;
+}

--- a/spec/fixtures/dynamic-template/component.js
+++ b/spec/fixtures/dynamic-template/component.js
@@ -1,0 +1,7 @@
+'use strict';
+
+require('./component.css');
+
+module.exports = function () {
+  return '<h1>Hello World</h1>';
+};

--- a/spec/fixtures/dynamic-template/index.html.js
+++ b/spec/fixtures/dynamic-template/index.html.js
@@ -1,0 +1,18 @@
+var component = require('./component');
+
+module.exports = function () {
+  // this could be a React`s renderToString
+  const content = component();
+
+  return [
+    '<!DOCTYPE html>',
+    '<html>',
+    '  <head>',
+    '    <meta charset="UTF-8">',
+    '  </head>',
+    '  <body>',
+    content,
+    '  </body>',
+    '</html>'
+  ].join('\n');
+};

--- a/spec/fixtures/dynamic-template/index.js
+++ b/spec/fixtures/dynamic-template/index.js
@@ -1,0 +1,3 @@
+var component = require('./component');
+
+document.body.innerHTML = component();


### PR DESCRIPTION
```
Module build failed: Error: "extract-text-webpack-plugin" loader is used without the corresponding plugin, refer to https://github.com/webpack/extract-text-webpack-plugin for the usage example
```

The use case that triggered this behavior for me was doing React’s `renderToString` of a component that has a dependency to a `.css` file.

Apparently the `ExtractTextPlugin` loader is configured properly, but the plugin not when we [create the createChildCompiler](https://github.com/ampedandwired/html-webpack-plugin/blob/master/lib/compiler.js#L44)

**This commit implements a test that demonstrates the issue.** but I'm not sure where to begging to fix it. Could you provide me some direction to start? I would gladly update this PR with a solution.
