### PR TITLE
Fix a bug where not all CSS files were injected

### DIFF
--- a/index.js
+++ b/index.js
@@ -388,7 +388,15 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
     // Will contain all js files
     js: [],
     // Will contain all css files
-    css: [],
+    css: Object.keys(compilation.assets).filter(function (assetFile) {
+      return path.extname(assetFile) === '.css';
+    }).map(function (cssFile) {
+      cssFile = publicPath + cssFile;
+      if (self.options.hash) {
+        cssFile = self.appendHash(cssFile, webpackStatsJson.hash);
+      }
+      return cssFile;
+    }),
     // Will contain the html5 appcache manifest files if it exists
     manifest: Object.keys(compilation.assets).filter(function (assetFile) {
       return path.extname(assetFile) === '.appcache';
@@ -426,20 +434,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
     assets.chunks[chunkName].entry = entry;
     assets.chunks[chunkName].hash = chunk.hash;
     assets.js.push(entry);
-
-    // Gather all css files
-    var css = chunkFiles.filter(function (chunkFile) {
-      // Some chunks may contain content hash in their names, for ex. 'main.css?1e7cac4e4d8b52fd5ccd2541146ef03f'.
-      // We must proper handle such cases, so we use regexp testing here
-      return /.css($|\?)/.test(chunkFile);
-    });
-    assets.chunks[chunkName].css = css;
-    assets.css = assets.css.concat(css);
   }
-
-  // Duplicate css assets can occur on occasion if more than one chunk
-  // requires the same css.
-  assets.css = _.uniq(assets.css);
 
   return assets;
 };

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -504,6 +504,97 @@ describe('HtmlWebpackPlugin', function () {
     }, ['<link href="styles.css?%hash%"'], null, done);
   });
 
+  it('should pick up css files exported with the file-loader', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: 'file-loader?name=styles.css' }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin()
+      ]
+    }, ['<link href="styles.css" rel="stylesheet">'], null, done);
+  });
+
+  it('should pick up css files exported with the file-loader on windows and protocol relative urls support (#205)', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js',
+        publicPath: '//localhost:8080/'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: 'file-loader?name=styles.css' }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin()
+      ]
+    }, ['<link href="//localhost:8080/styles.css"'], null, done);
+  });
+
+  it('should allow to add cache hashes css files that have been exported with the file-loader', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: 'file-loader?name=styles.css' }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin({hash: true})
+      ]
+    }, ['<link href="styles.css?%hash%"'], null, done);
+  });
+
+  it('should inject css files when using the file-loader to export css files', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: 'file-loader?name=styles.css' }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin({inject: true})
+      ]
+    }, ['<link href="styles.css"'], null, done);
+  });
+
+  it('should allow to add cache hashes to with injected css assets that have been exported with the file-loader', function (done) {
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /\.css$/, loader: 'file-loader?name=styles.css' }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin({hash: true, inject: true})
+      ]
+    }, ['<link href="styles.css?%hash%"'], null, done);
+  });
+
   it('should output xhtml link stylesheet tag', function (done) {
     var ExtractTextPlugin = require('extract-text-webpack-plugin');
     testHtmlPlugin({


### PR DESCRIPTION
This commit fixes a bug where CSS files were not recognized that have been exported with the file-loader.

Instead of searching all chunks for referenced CSS files and deduping it afterwards, we just skim all `compilation.assets` for CSS files. This allows us to also pick up CSS files that have been exported via the file-loader.

Use cases for this change:
- CSS files that have been processed with the [extract-loader](https://github.com/peerigon/extract-loader)
- CSS files that should be hashed and emitted to the output dir without processing it via the css-loader (because they are ready-to-use, for instance)

Since all previous tests are still working without changing them, I assume that this is not a breaking change.
