### PR TITLE
order of chunks if specifying none is determined by order of includedChunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -344,19 +344,19 @@ HtmlWebpackPlugin.prototype.sortChunks = function (chunks, sortMode) {
  * Return all chunks from the compilation result which match the exclude and include filters
  */
 HtmlWebpackPlugin.prototype.filterChunks = function (webpackStatsJson, includedChunks, excludedChunks) {
-    if (Array.isArray(includedChunks)) {
-        // Looping through the includedChunks instead of filtering,
-        // ensures that the order of the chunks is order of includedChunks
-        return includedChunks.map(function(name) {
-            for (var i=0; i < webpackStatsJson.chunks.length; i++) {
-                var chunk = webpackStatsJson.chunks[i];
-                if (chunk.names[0] === name) {
-                    return chunk;
-                }
-            }
-            // unknown chunk, ignore
-        })
-    };
+  if (Array.isArray(includedChunks)) {
+    // Looping through the includedChunks instead of filtering,
+    // ensures that the order of the chunks is order of includedChunks
+    return includedChunks.map(function(name) {
+      for (var i=0; i < webpackStatsJson.chunks.length; i++) {
+        var chunk = webpackStatsJson.chunks[i];
+        if (chunk.names[0] === name) {
+          return chunk;
+        }
+      }
+      // unknown chunk, ignore
+    });
+  }
 
   return webpackStatsJson.chunks.filter(function (chunk) {
     var chunkName = chunk.names[0];

--- a/index.js
+++ b/index.js
@@ -344,6 +344,20 @@ HtmlWebpackPlugin.prototype.sortChunks = function (chunks, sortMode) {
  * Return all chunks from the compilation result which match the exclude and include filters
  */
 HtmlWebpackPlugin.prototype.filterChunks = function (webpackStatsJson, includedChunks, excludedChunks) {
+    if (Array.isArray(includedChunks)) {
+        // Looping through the includedChunks instead of filtering,
+        // ensures that the order of the chunks is order of includedChunks
+        return includedChunks.map(function(name) {
+            for (var i=0; i < webpackStatsJson.chunks.length; i++) {
+                var chunk = webpackStatsJson.chunks[i];
+                if (chunk.names[0] === name) {
+                    return chunk;
+                }
+            }
+            // unknown chunk, ignore
+        })
+    };
+
   return webpackStatsJson.chunks.filter(function (chunk) {
     var chunkName = chunk.names[0];
     // This chunk doesn't have a name. This script can't handled it.
@@ -352,10 +366,6 @@ HtmlWebpackPlugin.prototype.filterChunks = function (webpackStatsJson, includedC
     }
     // Skip if the chunk should be lazy loaded
     if (!chunk.initial) {
-      return false;
-    }
-    // Skip if the chunks should be filtered and the given chunk was not added explicity
-    if (Array.isArray(includedChunks) && includedChunks.indexOf(chunkName) === -1) {
       return false;
     }
     // Skip if the chunks should be filtered and the given chunk was excluded explicity

--- a/index.js
+++ b/index.js
@@ -347,8 +347,8 @@ HtmlWebpackPlugin.prototype.filterChunks = function (webpackStatsJson, includedC
   if (Array.isArray(includedChunks)) {
     // Looping through the includedChunks instead of filtering,
     // ensures that the order of the chunks is order of includedChunks
-    return includedChunks.map(function(name) {
-      for (var i=0; i < webpackStatsJson.chunks.length; i++) {
+    return includedChunks.map(function (name) {
+      for (var i = 0; i < webpackStatsJson.chunks.length; i++) {
         var chunk = webpackStatsJson.chunks[i];
         if (chunk.names[0] === name) {
           return chunk;

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -1140,6 +1140,26 @@ describe('HtmlWebpackPlugin', function () {
       /<script type="text\/javascript" src="common_bundle.js">.+<script type="text\/javascript" src="util_bundle.js">.+<script type="text\/javascript" src="index_bundle.js">/], null, done);
   });
 
+  it('should not sort the chunks in the order provided in none mode', function (done) {
+    testHtmlPlugin({
+      entry: {
+        index: path.join(__dirname, 'fixtures/index.js'),
+        util: path.join(__dirname, 'fixtures/util.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          chunks: ['util', 'index'],
+          chunksSortMode: 'none'
+        })
+      ]
+    }, [
+      /<script type="text\/javascript" src="util_bundle.js">.+<script type="text\/javascript" src="index_bundle.js">/], null, done);
+  });
+
   it('should sort the chunks in custom (reverse alphabetical) order', function (done) {
     testHtmlPlugin({
       entry: {

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -1140,11 +1140,11 @@ describe('HtmlWebpackPlugin', function () {
       /<script type="text\/javascript" src="common_bundle.js">.+<script type="text\/javascript" src="util_bundle.js">.+<script type="text\/javascript" src="index_bundle.js">/], null, done);
   });
 
-  it('should not sort the chunks in the order provided in none mode', function (done) {
+  it('should sort the chunks in the order provided in none mode', function (done) {
     testHtmlPlugin({
       entry: {
-        index: path.join(__dirname, 'fixtures/index.js'),
-        util: path.join(__dirname, 'fixtures/util.js')
+        util: path.join(__dirname, 'fixtures/util.js'),
+        index: path.join(__dirname, 'fixtures/index.js')
       },
       output: {
         path: OUTPUT_DIR,


### PR DESCRIPTION
I have a use case where I would like the order of the chunks that is injected into the html to be as specified by the "chunks" array in the options. The problem is that when specifying 'none' as an sort method, the order becomes unpredictable if the entries in the webpack config is specified as a hash. 

I have added a test that shows the use case and also code that resolves it.
Let me know if you need more information.
