### PR TITLE
Infer link element media attribute from CSS filenames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /dist/
 npm-debug.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ If you have any CSS assets in webpack's output (for example, CSS extracted
 with the [ExtractTextPlugin](https://github.com/webpack/extract-text-webpack-plugin))
 then these will be included with `<link>` tags in the HTML head.
 
+If you want to automatically set the `<link>` element [`media` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#Attributes), ensure the extracted CSS file name includes "media_{base64MediaString}":
+
+```
+style.media_KG1pbi13aWR0aDogNzAwcHgpLCBoYW5kaGVsZCBhbmQgKG9yaWVudGF0aW9uOiBsYW5kc2NhcGUp.css
+
+will be injected into the HTML template as:
+
+<link src="styles.media_KG1pbi13aWR0aDogNzAwcHgpLCBoYW5kaGVsZCBhbmQgKG9yaWVudGF0aW9uOiBsYW5kc2NhcGUp.css" rel="stylesheet" media="(min-width: 700px), handheld and (orientation: landscape)" />
+```
+
 Configuration
 -------------
 You can pass a hash of configuration options to `HtmlWebpackPlugin`.

--- a/index.js
+++ b/index.js
@@ -447,6 +447,22 @@ module.exports = class HtmlWebpackPlugin {
     return assets;
   }
 
+  inferMediaFromCSSFilename (filename) {
+    const matches = filename.match(/\bmedia_([A-Z0-9=]*)/i);
+
+    if (matches) {
+      // Node 5.10+
+      if (typeof Buffer.from === 'function') {
+        return Buffer.from(matches[1], 'base64');
+      }
+
+      // older Node versions
+      return new Buffer(matches[1], 'base64');
+    }
+
+    return false;
+  }
+
   /**
    * Injects the assets into the given html string
    */
@@ -458,7 +474,8 @@ module.exports = class HtmlWebpackPlugin {
     // Turn css files into link tags
     const styles = assets.css.map(stylePath => htmlTag.createHtmlTagObject('link', {
       href: stylePath,
-      rel: 'stylesheet'
+      rel: 'stylesheet',
+      media: this.inferMediaFromCSSFilename(stylePath)
     }));
     // Injection targets
     let head = [];

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -525,6 +525,31 @@ describe('HtmlWebpackPlugin', function () {
     }, ['<link href="styles.css" rel="stylesheet"/>'], null, done);
   });
 
+  it('should output xhtml link stylesheet tag with media attribute when inferred from the filename', function (done) {
+    var ExtractTextPlugin = require('extract-text-webpack-plugin');
+    var printExtractor = new ExtractTextPlugin('styles.media_KG1pbi13aWR0aDogNzAwcHgpLCBoYW5kaGVsZCBhbmQgKG9yaWVudGF0aW9uOiBsYW5kc2NhcGUp.css');
+    var styleExtractor = new ExtractTextPlugin('styles.css');
+
+    testHtmlPlugin({
+      entry: path.join(__dirname, 'fixtures/theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        loaders: [
+          { test: /print\.css$/, loader: printExtractor.extract('style-loader', 'css-loader') },
+          { test: /\.css$/, exclude: /print\.css$/, loader: styleExtractor.extract('style-loader', 'css-loader') }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin({xhtml: true}),
+        printExtractor,
+        styleExtractor
+      ]
+    }, ['<link href="styles.media_KG1pbi13aWR0aDogNzAwcHgpLCBoYW5kaGVsZCBhbmQgKG9yaWVudGF0aW9uOiBsYW5kc2NhcGUp.css" rel="stylesheet" media="(min-width: 700px), handheld and (orientation: landscape)"/>'], null, done);
+  });
+
   it('prepends the webpack public path to script src', function (done) {
     testHtmlPlugin({
       entry: path.join(__dirname, 'fixtures/index.js'),

--- a/spec/fixtures/print.css
+++ b/spec/fixtures/print.css
@@ -1,0 +1,5 @@
+@media print {
+    body {
+      background: #FFF;
+    }
+}

--- a/spec/fixtures/theme.js
+++ b/spec/fixtures/theme.js
@@ -1,4 +1,5 @@
 'use strict';
 
 require('./main.css');
+require('./print.css');
 require('./index.js');


### PR DESCRIPTION
This allows for things like print stylesheets and desktop or mobile-only styles to be isolated and conditionally loaded by the browser.

Closes #582 