### PR TITLE
this.resourcePath will avoid not skipping resource file with query params

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -17,7 +17,7 @@ module.exports = function (source) {
     return source;
   }
   // Skip .js files
-  if (/\.js$/.test(this.request)) {
+  if (/\.js$/.test(this.resourcePath)) {
     return source;
   }
 


### PR DESCRIPTION
this.resourcePath will avoid not skipping resource file with query params