### PR TITLE
Option to inject variables to template context

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Allowed values are as follows:
 - `chunksSortMode`: Allows to control how chunks should be sorted before they are included to the html. Allowed values: 'none' | 'auto' | 'dependency' | {function} - default: 'auto'
 - `excludeChunks`: Allows you to skip some chunks (e.g. don't add the unit-test chunk)
 - `xhtml`: `true | false` If `true` render the `link` tags as self-closing, XHTML compliant. Default is `false`
+- `variables`: `{...}` Map of variables that get injected to template context while processing. Useful when template is a function.
 
 Here's an example webpack config illustrating how to use these options:
 ```javascript

--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ HtmlWebpackPlugin.prototype.evaluateCompilationResult = function (compilation, s
   // To extract the result during the evaluation this part has to be removed.
   source = source.replace('var HTML_WEBPACK_PLUGIN_RESULT =', '');
   var template = this.options.template.replace(/^.+!/, '').replace(/\?.+$/, '');
-  var vmContext = vm.createContext(_.extend({HTML_WEBPACK_PLUGIN: true, require: require}, global));
+  var vmContext = vm.createContext(_.extend({HTML_WEBPACK_PLUGIN: true, require: require}, global, this.options.variables));
   var vmScript = new vm.Script(source, {filename: template});
   // Evaluate code and cast to string
   var newSource;


### PR DESCRIPTION
When using `html-loader` with `interpolate` option, the returned template is a function, not a plain string. This function is then run by html-webpack-plugin, but there is no way of passing any useful values to it. `require` is the only useful function injected currently.

This change adds `variables` option to configuration, which provides variables and values that the template function will have access to and can for example iterate over generating template code.