### PR TITLE
Updated 'text/javascript' to 'application/javascript

### DIFF
--- a/index.js
+++ b/index.js
@@ -472,7 +472,7 @@ HtmlWebpackPlugin.prototype.generateAssetTags = function (assets) {
       tagName: 'script',
       closeTag: true,
       attributes: {
-        type: 'text/javascript',
+        type: 'application/javascript',
         src: scriptPath
       }
     };


### PR DESCRIPTION
'text/javascript' is obsolete . Instead 'application/javascript' should be used
See issue 645 for details :  https://github.com/jantimon/html-webpack-plugin/issues/645