### PR TITLE
Link plugin for inlining chunk manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ There are already some really powerful plugins which can be integrated with zero
  * [resource-hints-webpack-plugin](https://github.com/jantimon/resource-hints-webpack-plugin) to add resource hints for faster initial page loads using `<link rel='preload'>` and `<link rel='prefetch'>`
  * [preload-webpack-plugin](https://github.com/GoogleChrome/preload-webpack-plugin) for automatically wiring up asynchronous (and other types) of JavaScript chunks using `<link rel='preload'>` helping with lazy-loading
  * [link-media-html-webpack-plugin](https://github.com/yaycmyk/link-media-html-webpack-plugin) allows for injected stylesheet `<link />` tags to have their media attribute set automatically; useful for providing specific desktop/mobile/print etc. stylesheets that the browser will conditionally download
+ * [inline-chunk-manifest-html-webpack-plugin](https://github.com/jouni-kantola/inline-chunk-manifest-html-webpack-plugin) for inlining webpack's chunk manifest. Default extracts manifest and inlines in `<head>`.
 
 Basic Usage
 -----------


### PR DESCRIPTION
As discussed in issue https://github.com/jantimon/html-webpack-plugin/issues/600, [inline-chunk-manifest-html-webpack-plugin](https://github.com/jouni-kantola/inline-chunk-manifest-html-webpack-plugin) handles the usecase of inlining webpack's chunk manifest.

This PR is to link to `inline-chunk-manifest-html-webpack-plugin`, with description for the plugin's default scenario (which can be overriden).