### PR TITLE
Make example more explicit about filename

### DIFF
--- a/docs/template-option.md
+++ b/docs/template-option.md
@@ -21,6 +21,17 @@ There are three ways to set the loader:
 
 By default (if you don't specify any loader in any way) a [fallback ejs loader](https://github.com/ampedandwired/html-webpack-plugin/blob/master/lib/loader.js) kicks in.
 
+```js
+{
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: 'src/index.ejs'
+    })
+  ]
+}
+```
+It is a good idea to use `.ejs` instead of `.html` so you do not unexpectedly trigger another loader.
+
 ## 2) Setting a loader directly for the template
 
 ```js


### PR DESCRIPTION
I lost half a day because I also had a file loader for .html and somehow the output got garbled. Hopefully this will help someone else.