### PR TITLE
docs(README): clearer explanation about minify

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Allowed values are as follows:
 - `template`: Webpack require path to the template. Please see the [docs](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md) for details.
 - `inject`: `true | 'head' | 'body' | false` Inject all assets into the given `template` or `templateContent` - When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element.
 - `favicon`: Adds the given favicon path to the output html.
-- `minify`: `{...} | false` Pass a [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference) options object to minify the output.
+- `minify`: `{...} | false` Pass [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference)'s options as object to minify the output.
 - `hash`: `true | false` if `true` then append a unique webpack compilation hash to all
   included scripts and CSS files. This is useful for cache busting.
 - `cache`: `true | false` if `true` (default) try to emit the file only if it was changed.


### PR DESCRIPTION
As read like this, I thought I had to import html-minifier and give the object as parameter like:

```javascript
import htmlMinifier from 'html-minifier'

new HtmlWebpackPlugin({
        template: 'src/index.html',
        minify: htmlMinifier,
      }),
```