### PR TITLE
Get html-webpack-plugin working with AggressiveSplittingPlugin

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -63,6 +63,25 @@ module.exports.compileTemplate = function compileTemplate (template, context, ou
       }
       compilation.cache = compilation.cache[compilerName];
     }
+    
+    compilation.plugin('after-optimize-chunks', function (chunks) {
+      // The rest of this plugin assumes there is only one chunk, however other plugins, such as the
+      // AggressiveSplittingPlugin may well have split this up into multiple chunks. We just combine
+      // the chunks again here.
+      var entryChunk = chunks.find(function (chunk) {
+        return chunk.hasEntryModule();
+      });
+
+      chunks.forEach(function (chunk, idx) {
+        if (chunk !== entryChunk) {
+          mergeChunks(entryChunk, chunk, 'html-webpack-plugin recombination');
+          chunks.splice(idx, 1);
+        }
+      });
+
+      // Set the entrypoint chunk so that we get the webpack runtime
+      entryChunk.entrypoints[0].chunks = [entryChunk];
+    });
   });
 
   // Compile and return a promise
@@ -109,4 +128,44 @@ function getCompilerName (context, filename) {
   var absolutePath = path.resolve(context, filename);
   var relativePath = path.relative(context, absolutePath);
   return 'html-webpack-plugin for "' + (absolutePath.length < relativePath.length ? absolutePath : relativePath) + '"';
+}
+
+function mergeChunks(thisChunk, otherChunk, reason) {
+  const otherChunkModules = otherChunk.modules.slice();
+	otherChunkModules.forEach(module => otherChunk.moveModule(module, thisChunk));
+	otherChunk.modules.length = 0;
+
+	otherChunk.parents.forEach(parentChunk => parentChunk.replaceChunk(otherChunk, thisChunk));
+	otherChunk.parents.length = 0;
+
+	otherChunk.chunks.forEach(chunk => chunk.replaceParentChunk(otherChunk, thisChunk));
+	otherChunk.chunks.length = 0;
+
+	otherChunk.blocks.forEach(b => {
+		b.chunks = b.chunks ? b.chunks.map(c => {
+			return c === otherChunk ? thisChunk : c;
+		}) : [thisChunk];
+		b.chunkReason = reason;
+		thisChunk.addBlock(b);
+	});
+	otherChunk.blocks.length = 0;
+
+	otherChunk.origins.forEach(origin => {
+		thisChunk.origins.push(origin);
+	});
+	thisChunk.origins.forEach(origin => {
+		if(!origin.reasons) {
+			origin.reasons = [reason];
+		} else if(origin.reasons[0] !== reason) {
+			origin.reasons.unshift(reason);
+		}
+	});
+	thisChunk.chunks = thisChunk.chunks.filter(chunk => {
+		return chunk !== otherChunk && chunk !== thisChunk;
+	});
+	thisChunk.parents = thisChunk.parents.filter(parentChunk => {
+		return parentChunk !== otherChunk && parentChunk !== thisChunk;
+	});
+
+	return true;
 }


### PR DESCRIPTION
As discussed in #446 and #599 this plugin doesn't play well with the AggressiveSplittingPlugin. This PR aims to address that.

The problem is that the html-webpack-plugin uses a child compiler to build out the necessary resources. This child compiler will inherit the AggressiveSplittingPlugin if present, which may cause multiple chunks to be emitted. Whilst it would be nice to get the AggresiveSplittingPlugin changed so that we could (e.g.) optionally disable it, from a practical perspective there's a quick win here, which is just to recombine any chunks created by the child compiler (which is what this PR does). It also has the benefit of working with any other plugins which happen to split the code up into multiple chunks.

Let me know what more you require to get this integrated