### PR TITLE
README.md updated path property in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var webpackConfig = {
   entry: 'index.js',
   output: {
-    path: 'dist',
+    path: __dirname + '/dist',
     filename: 'index_bundle.js'
   },
   plugins: [new HtmlWebpackPlugin()]
@@ -104,7 +104,7 @@ Here's an example webpack config illustrating how to use these options:
 {
   entry: 'index.js',
   output: {
-    path: 'dist',
+    path: __dirname + '/dist',
     filename: 'index_bundle.js'
   },
   plugins: [
@@ -131,7 +131,7 @@ once in your plugins array:
 {
   entry: 'index.js',
   output: {
-    path: 'dist',
+    path: __dirname + '/dist',
     filename: 'index_bundle.js'
   },
   plugins: [


### PR DESCRIPTION
In 2.6.1, 
   output: {
        path: 'dist',
        filename: 'app.bundle.js'
    }

give the below error.

The provided value "dist" is not an absolute path!

So made, path: 
output: {
    path: __dirname + '/dist',
    filename: 'index_bundle.js'
  }