### PR TITLE
add prefix to make things easy for s3 stuff

### DIFF
--- a/index.js
+++ b/index.js
@@ -523,6 +523,21 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function (html, assets, asset
   var htmlRegExp = /(<html[^>]*>)/i;
   var headRegExp = /(<\/head>)/i;
   var bodyRegExp = /(<\/body>)/i;
+  var prefix = this.options.prefix
+  if (prefix) {
+    assetTags.body = assetTags.body.map(function(tag){
+      if (tag.attributes.src) {
+        tag.attributes.src = prefix + tag.attributes.src
+      }
+      return tag  
+    })
+    assetTags.head = assetTags.head.map(function(tag){
+      if (tag.attributes.href) {
+        tag.attributes.href = prefix + tag.attributes.href
+      }
+      return tag  
+    })
+  }
   var body = assetTags.body.map(this.createHtmlTag);
   var head = assetTags.head.map(this.createHtmlTag);
 

--- a/index.js
+++ b/index.js
@@ -523,20 +523,20 @@ HtmlWebpackPlugin.prototype.injectAssetsIntoHtml = function (html, assets, asset
   var htmlRegExp = /(<html[^>]*>)/i;
   var headRegExp = /(<\/head>)/i;
   var bodyRegExp = /(<\/body>)/i;
-  var prefix = this.options.prefix
+  var prefix = this.options.prefix;
   if (prefix) {
-    assetTags.body = assetTags.body.map(function(tag){
+    assetTags.body = assetTags.body.map(function (tag) {
       if (tag.attributes.src) {
-        tag.attributes.src = prefix + tag.attributes.src
+        tag.attributes.src = prefix + tag.attributes.src;
       }
-      return tag  
-    })
-    assetTags.head = assetTags.head.map(function(tag){
+      return tag;
+    });
+    assetTags.head = assetTags.head.map(function (tag) {
       if (tag.attributes.href) {
-        tag.attributes.href = prefix + tag.attributes.href
+        tag.attributes.href = prefix + tag.attributes.href;
       }
-      return tag  
-    })
+      return tag;
+    });
   }
   var body = assetTags.body.map(this.createHtmlTag);
   var head = assetTags.head.map(this.createHtmlTag);


### PR DESCRIPTION
If you upload your js and css files to the cloud after compilation and you will wish the html file `src` and `href` to be prefixed with the given string. e.g. `<script type="text/javascript" src="http://cdn.example.com/js/main.js">` or `<link href="http://cdn.example.com/css/main.css" rel="stylesheet">`. These lines enable this by an option `prefix`. It's totally harmless if you don't set this option.