### PR TITLE
Add the option "templateArgs" in order to pass custom arguments to the template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Allowed values are as follows:
 - `filename`: The file to write the HTML to. Defaults to `index.html`.
    You can specify a subdirectory here too (eg: `assets/admin.html`).
 - `template`: Webpack require path to the template. Please see the [docs](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md) for details.
-- `templateArgs`: Allows you to pass custom template arguments to your template. Expects an object.
+- `templateArgs`: Allows you to pass custom template arguments to your template. Expects an object or a function that returns an object.
 - `inject`: `true | 'head' | 'body' | false` Inject all assets into the given `template` or `templateContent` - When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element.
 - `favicon`: Adds the given favicon path to the output html.
 - `minify`: `{...} | false` Pass [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference)'s options as object to minify the output.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Allowed values are as follows:
 - `filename`: The file to write the HTML to. Defaults to `index.html`.
    You can specify a subdirectory here too (eg: `assets/admin.html`).
 - `template`: Webpack require path to the template. Please see the [docs](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md) for details.
+- `templateArgs`: Allows you to pass custom template arguments to your template. Expects an object.
 - `inject`: `true | 'head' | 'body' | false` Inject all assets into the given `template` or `templateContent` - When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element.
 - `favicon`: Adds the given favicon path to the output html.
 - `minify`: `{...} | false` Pass [html-minifier](https://github.com/kangax/html-minifier#options-quick-reference)'s options as object to minify the output.

--- a/index.js
+++ b/index.js
@@ -251,6 +251,11 @@ HtmlWebpackPlugin.prototype.executeTemplate = function (templateFunction, chunks
   return Promise.resolve()
     // Template processing
     .then(function () {
+      let templateArgs = self.options.templateArgs;
+      if (typeof self.options.templateArgs === 'function') {
+        templateArgs = self.options.templateArgs();
+      }
+
       var templateParams = _.extend({
         compilation: compilation,
         webpack: compilation.getStats().toJson(),
@@ -259,7 +264,7 @@ HtmlWebpackPlugin.prototype.executeTemplate = function (templateFunction, chunks
           files: assets,
           options: self.options
         }
-      }, self.options.templateArgs);
+      }, templateArgs);
       var html = '';
       try {
         html = templateFunction(templateParams);

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function HtmlWebpackPlugin (options) {
   // Default options
   this.options = _.extend({
     template: path.join(__dirname, 'default_index.ejs'),
+    templateArgs: {},
     filename: 'index.html',
     hash: false,
     inject: true,
@@ -250,7 +251,7 @@ HtmlWebpackPlugin.prototype.executeTemplate = function (templateFunction, chunks
   return Promise.resolve()
     // Template processing
     .then(function () {
-      var templateParams = {
+      var templateParams = _.extend({
         compilation: compilation,
         webpack: compilation.getStats().toJson(),
         webpackConfig: compilation.options,
@@ -258,7 +259,7 @@ HtmlWebpackPlugin.prototype.executeTemplate = function (templateFunction, chunks
           files: assets,
           options: self.options
         }
-      };
+      }, self.options.templateArgs);
       var html = '';
       try {
         html = templateFunction(templateParams);

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -1537,4 +1537,30 @@ describe('HtmlWebpackPlugin', function () {
     },
     [messages.map(function (msg) { return '<div>' + msg + '</div>'; }).join('') + '<script type="text/javascript" src="app_bundle.js"></script>'], null, done);
   });
+
+  it('allows to pass template arguments by function', function (done) {
+    function templateArgs () {
+      return {
+        messages: Array.apply(null, new Array(5)).map(function (_, index) {
+          return 'msg' + index.toString(10);
+        })
+      };
+    }
+    let messages = templateArgs().messages;
+
+    testHtmlPlugin({
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'app_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        template: 'jade-loader!' + path.join(__dirname, 'fixtures/template_with_args.jade'),
+        templateArgs: templateArgs
+      })]
+    },
+    [messages.map(function (msg) { return '<div>' + msg + '</div>'; }).join('') + '<script type="text/javascript" src="app_bundle.js"></script>'], null, done);
+  });
 });

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -1513,4 +1513,28 @@ describe('HtmlWebpackPlugin', function () {
     },
     [/^<script type="text\/javascript" src="app_bundle\.js"><\/script>$/], null, done);
   });
+
+  it('allows to pass template arguments by specifying templateArgs options', function (done) {
+    var messages = Array.apply(null, new Array(5))
+      .map(function (_, index) {
+        return 'msg' + index.toString(10);
+      });
+
+    testHtmlPlugin({
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'app_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        template: 'jade-loader!' + path.join(__dirname, 'fixtures/template_with_args.jade'),
+        templateArgs: {
+          messages: messages
+        }
+      })]
+    },
+    [messages.map(function (msg) { return '<div>' + msg + '</div>'; }).join('') + '<script type="text/javascript" src="app_bundle.js"></script>'], null, done);
+  });
 });

--- a/spec/fixtures/template_with_args.jade
+++ b/spec/fixtures/template_with_args.jade
@@ -1,0 +1,4 @@
+html
+  body
+    each msg in messages
+      div #{msg}


### PR DESCRIPTION
This PR add the option `templateArgs` which enables users to pass custom arguments to the template.

Currently, this is only possible when you pass these arguments inside the options of `HtmlWebpackPlugin` but this leads to long illegible template argument references inside the templates.  In addition, this behavior is not documented, so I think it is a not intended feature.  Therefore, I think that a dedicated options for this use case is desirable.





