### PR TITLE
Uses a singleton cache to store the compilation stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,14 @@ var prettyError = require('./lib/errors.js');
 var chunkSorter = require('./lib/chunksorter.js');
 Promise.promisifyAll(fs);
 
+var getStats = (function () {
+  var cachedStats = null;
+  return function (compilation) {
+    cachedStats = cachedStats || compilation.getStats().toJson();
+    return cachedStats;
+  };
+}());
+
 function HtmlWebpackPlugin (options) {
   // Default options
   this.options = _.extend({
@@ -65,7 +73,7 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
   compiler.plugin('emit', function (compilation, callback) {
     var applyPluginsAsyncWaterfall = self.applyPluginsAsyncWaterfall(compilation);
     // Get all chunks
-    var allChunks = compilation.getStats().toJson().chunks;
+    var allChunks = getStats(compilation).chunks;
     // Filter chunks (options.chunks and options.excludeCHunks)
     var chunks = self.filterChunks(allChunks, self.options.chunks, self.options.excludeChunks);
     // Sort chunks
@@ -252,7 +260,7 @@ HtmlWebpackPlugin.prototype.executeTemplate = function (templateFunction, chunks
     .then(function () {
       var templateParams = {
         compilation: compilation,
-        webpack: compilation.getStats().toJson(),
+        webpack: getStats(compilation),
         webpackConfig: compilation.options,
         htmlWebpackPlugin: {
           files: assets,
@@ -384,7 +392,7 @@ HtmlWebpackPlugin.prototype.isHotUpdateCompilation = function (assets) {
 
 HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chunks) {
   var self = this;
-  var webpackStatsJson = compilation.getStats().toJson();
+  var webpackStatsJson = getStats(compilation);
 
   // Use the configured public path or build a relative path
   var publicPath = typeof compilation.options.output.publicPath !== 'undefined'

--- a/index.js
+++ b/index.js
@@ -360,7 +360,11 @@ HtmlWebpackPlugin.prototype.filterChunks = function (chunks, includedChunks, exc
       return false;
     }
     // Skip if the chunk should be lazy loaded
-    if (!chunk.initial) {
+    if (typeof chunk.isInitial === 'function') {
+      if (!chunk.isInitial()) {
+        return false;
+      }
+    } else if (!chunk.initial) {
       return false;
     }
     // Skip if the chunks should be filtered and the given chunk was not added explicity

--- a/index.js
+++ b/index.js
@@ -66,7 +66,6 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
     var applyPluginsAsyncWaterfall = self.applyPluginsAsyncWaterfall(compilation);
     // Get all chunks
     var allChunks = compilation.chunks;
-    debugger;
     // Filter chunks (options.chunks and options.excludeCHunks)
     var chunks = self.filterChunks(allChunks, self.options.chunks, self.options.excludeChunks);
     // Sort chunks

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
   compiler.plugin('emit', function (compilation, callback) {
     var applyPluginsAsyncWaterfall = self.applyPluginsAsyncWaterfall(compilation);
     // Get all chunks
-    var allChunks = compilation.chunks;
+    var allChunks = compilation.getStats().toJson().chunks;
     // Filter chunks (options.chunks and options.excludeCHunks)
     var chunks = self.filterChunks(allChunks, self.options.chunks, self.options.excludeChunks);
     // Sort chunks
@@ -354,7 +354,7 @@ HtmlWebpackPlugin.prototype.sortChunks = function (chunks, sortMode) {
  */
 HtmlWebpackPlugin.prototype.filterChunks = function (chunks, includedChunks, excludedChunks) {
   return chunks.filter(function (chunk) {
-    var chunkName = chunk.name;
+    var chunkName = chunk.names[0];
     // This chunk doesn't have a name. This script can't handled it.
     if (chunkName === undefined) {
       return false;
@@ -425,7 +425,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
 
   for (var i = 0; i < chunks.length; i++) {
     var chunk = chunks[i];
-    var chunkName = chunk.name;
+    var chunkName = chunk.names[0];
 
     assets.chunks[chunkName] = {};
 
@@ -446,7 +446,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
     var entry = chunkFiles[0];
     assets.chunks[chunkName].size = chunk.size;
     assets.chunks[chunkName].entry = entry;
-    assets.chunks[chunkName].hash = chunk.renderedHash;
+    assets.chunks[chunkName].hash = chunk.hash;
     assets.js.push(entry);
 
     // Gather all css files

--- a/index.js
+++ b/index.js
@@ -9,16 +9,6 @@ var prettyError = require('./lib/errors.js');
 var chunkSorter = require('./lib/chunksorter.js');
 Promise.promisifyAll(fs);
 
-var getStats = (function () {
-  var cachedStats = {};
-
-  return function (compilation) {
-    var hash = compilation.hash;
-    cachedStats[hash] = cachedStats[hash] || compilation.getStats().toJson();
-    return cachedStats[hash];
-  };
-}());
-
 function HtmlWebpackPlugin (options) {
   // Default options
   this.options = _.extend({
@@ -75,7 +65,8 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
   compiler.plugin('emit', function (compilation, callback) {
     var applyPluginsAsyncWaterfall = self.applyPluginsAsyncWaterfall(compilation);
     // Get all chunks
-    var allChunks = getStats(compilation).chunks;
+    var allChunks = compilation.chunks;
+    debugger;
     // Filter chunks (options.chunks and options.excludeCHunks)
     var chunks = self.filterChunks(allChunks, self.options.chunks, self.options.excludeChunks);
     // Sort chunks
@@ -262,7 +253,7 @@ HtmlWebpackPlugin.prototype.executeTemplate = function (templateFunction, chunks
     .then(function () {
       var templateParams = {
         compilation: compilation,
-        webpack: getStats(compilation),
+        webpack: compilation.getStats(),
         webpackConfig: compilation.options,
         htmlWebpackPlugin: {
           files: assets,
@@ -364,7 +355,7 @@ HtmlWebpackPlugin.prototype.sortChunks = function (chunks, sortMode) {
  */
 HtmlWebpackPlugin.prototype.filterChunks = function (chunks, includedChunks, excludedChunks) {
   return chunks.filter(function (chunk) {
-    var chunkName = chunk.names[0];
+    var chunkName = chunk.name;
     // This chunk doesn't have a name. This script can't handled it.
     if (chunkName === undefined) {
       return false;
@@ -394,12 +385,12 @@ HtmlWebpackPlugin.prototype.isHotUpdateCompilation = function (assets) {
 
 HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chunks) {
   var self = this;
-  var webpackStatsJson = getStats(compilation);
+  var compilationHash = compilation.hash;
 
   // Use the configured public path or build a relative path
   var publicPath = typeof compilation.options.output.publicPath !== 'undefined'
     // If a hard coded public path exists use it
-    ? compilation.mainTemplate.getPublicPath({hash: webpackStatsJson.hash})
+    ? compilation.mainTemplate.getPublicPath({hash: compilationHash})
     // If no public path was set get a relative url path
     : path.relative(path.resolve(compilation.options.output.path, path.dirname(self.childCompilationOutputName)), compilation.options.output.path)
       .split(path.sep).join('/');
@@ -425,13 +416,13 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
 
   // Append a hash for cache busting
   if (this.options.hash) {
-    assets.manifest = self.appendHash(assets.manifest, webpackStatsJson.hash);
-    assets.favicon = self.appendHash(assets.favicon, webpackStatsJson.hash);
+    assets.manifest = self.appendHash(assets.manifest, compilationHash);
+    assets.favicon = self.appendHash(assets.favicon, compilationHash);
   }
 
   for (var i = 0; i < chunks.length; i++) {
     var chunk = chunks[i];
-    var chunkName = chunk.names[0];
+    var chunkName = chunk.name;
 
     assets.chunks[chunkName] = {};
 
@@ -443,7 +434,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
     // Append a hash for cache busting
     if (this.options.hash) {
       chunkFiles = chunkFiles.map(function (chunkFile) {
-        return self.appendHash(chunkFile, webpackStatsJson.hash);
+        return self.appendHash(chunkFile, compilationHash);
       });
     }
 
@@ -452,7 +443,7 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
     var entry = chunkFiles[0];
     assets.chunks[chunkName].size = chunk.size;
     assets.chunks[chunkName].entry = entry;
-    assets.chunks[chunkName].hash = chunk.hash;
+    assets.chunks[chunkName].hash = chunk.renderedHash;
     assets.js.push(entry);
 
     // Gather all css files

--- a/index.js
+++ b/index.js
@@ -10,10 +10,12 @@ var chunkSorter = require('./lib/chunksorter.js');
 Promise.promisifyAll(fs);
 
 var getStats = (function () {
-  var cachedStats = null;
+  var cachedStats = {};
+
   return function (compilation) {
-    cachedStats = cachedStats || compilation.getStats().toJson();
-    return cachedStats;
+    var hash = compilation.hash;
+    cachedStats[hash] = cachedStats[hash] || compilation.getStats().toJson();
+    return cachedStats[hash];
   };
 }());
 

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -1414,10 +1414,10 @@ describe('HtmlWebpackPlugin', function () {
       plugins: [
         new HtmlWebpackPlugin({
           chunksSortMode: function (a, b) {
-            if (a.name < b.name) {
+            if (a.names[0] < b.names[0]) {
               return 1;
             }
-            if (a.name > b.name) {
+            if (a.names[0] > b.names[0]) {
               return -1;
             }
             return 0;

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -1414,10 +1414,10 @@ describe('HtmlWebpackPlugin', function () {
       plugins: [
         new HtmlWebpackPlugin({
           chunksSortMode: function (a, b) {
-            if (a.names[0] < b.names[0]) {
+            if (a.name < b.name) {
               return 1;
             }
-            if (a.names[0] > b.names[0]) {
+            if (a.name > b.name) {
               return -1;
             }
             return 0;


### PR DESCRIPTION
This PR introduces a singleton cache for the compilation stats.

In large Webpack builds generating the stats takes a while and each generated html pays that cost three times. Moreover, if the build uses multiple instances of HtmlWebpackPlugin to generate more than one html file, this cost is payed for each template.

In my local case, I have ~2000 modules and 18 html templates, which normally takes around 175 seconds. With this change, the time goes down to 148 seconds, a 15% improvement.