### PR TITLE
Fix AppCache publicPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,7 +399,9 @@ module.exports = class HtmlWebpackPlugin {
       // Will contain all css files
       css: [],
       // Will contain the html5 appcache manifest files if it exists
-      manifest: Object.keys(compilation.assets).filter(assetFile => path.extname(assetFile) === '.appcache')[0]
+      manifest: Object.keys(compilation.assets)
+        .filter(assetFile => path.extname(assetFile) === '.appcache')
+        .map(assetFile => compilation.assets[assetFile].assets[0])[0]
     };
 
     // Append a hash for cache busting


### PR DESCRIPTION
This is a better fix than https://github.com/jantimon/html-webpack-plugin/pull/711

Looking at this commit and their test, they already solved this in the appcache plugin https://github.com/lettertwo/appcache-webpack-plugin/commit/d35a0b6ba5122d123c0a9ccf8b05e549d0cfa01a