### PR TITLE
default sortMode should be 'dependency' on webpack3

### DIFF
--- a/lib/chunksorter.js
+++ b/lib/chunksorter.js
@@ -85,9 +85,9 @@ module.exports.none = function (chunks) {
  */
 module.exports.auto = module.exports.id;
 
-// In webpack 2 the ids have been flipped.
+// In webpack 2+ the ids have been flipped.
 // Therefore the id sort doesn't work the same way as it did for webpack 1
 // Luckily the dependency sort is working as expected
-if (require('webpack/package.json').version.split('.')[0] === '2') {
+if (Number(require('webpack/package.json').version.split('.')[0]) >= 2) {
   module.exports.auto = module.exports.dependency;
 }


### PR DESCRIPTION
Default sortMode should be 'dependency' on webpack3, otherwise the order of chunks would be mess In some cases.