### PR TITLE
Listing html-webpack-externals-plugin in third-party addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ There are already some really powerful plugins which can be integrated with zero
  * [html-webpack-inline-source-plugin](https://github.com/DustinJackson/html-webpack-inline-source-plugin) to inline your assets in the resulting HTML file
  * [html-webpack-exclude-assets-plugin](https://github.com/jamesjieye/html-webpack-exclude-assets-plugin) for excluding assets using regular expressions
  * [html-webpack-include-assets-plugin](https://github.com/jharris4/html-webpack-include-assets-plugin) for including lists of js or css file paths (such as those copied by the copy-webpack-plugin).
+ * [html-webpack-externals-plugin](https://github.com/mmiller42/html-webpack-externals-plugin) for defining pre-built CSS and JS modules to exclude from your bundle chunks, then copy into the output (or use CDNs) and inject into HTML
  * [script-ext-html-webpack-plugin](https://github.com/numical/script-ext-html-webpack-plugin) to add `async`, `defer` or `module` attributes to your`<script>` elements, or even in-line them
  * [style-ext-html-webpack-plugin](https://github.com/numical/style-ext-html-webpack-plugin) to convert your `<link>`s to external stylesheets into `<style>` elements containing internal CSS
  * [resource-hints-webpack-plugin](https://github.com/jantimon/resource-hints-webpack-plugin) to add resource hints for faster initial page loads using `<link rel='preload'>` and `<link rel='prefetch'>`


### PR DESCRIPTION
I'd like to propose adding my plugin to your third party addons section in the readme.

I created the [`html-webpack-externals-plugin`](https://github.com/mmiller42/html-webpack-externals-plugin) to simplify combining the `html-webpack-plugin` with the use of Webpack externals (modules that are not processed by Webpack/excluded from bundles).

This plugin is very simple and just encapsulates two other Webpack plugins to do the heavy lifting. It:

1. modifies your Webpack config at runtime to add your vendor modules to the [`externals`](https://webpack.js.org/configuration/externals/) property.
1. runs the [`copy-webpack-plugin`](https://github.com/kevlened/copy-webpack-plugin) to copy your vendor module assets into the output path.
1. runs the [`html-webpack-include-assets-plugin`](https://github.com/jharris4/html-webpack-include-assets-plugin) to add your vendor module bundles to the HTML output.

Basically, it replaces this:

```js
plugins: [
  new HtmlWebpackPlugin({
    filename: 'index.html',
    template: 'src/index.html',
  }),
  new CopyWebpackPlugin([
    { from: 'node_modules/react/dist/react.js', to: 'vendor/react/dist/react.js' },
    { from: 'node_modules/react-dom/dist/react-dom.js', to: 'vendor/react-dom/dist/react-dom.js' },
    { from: 'node_modules/semantic-ui-css/semantic.css', to: 'vendor/semantic-ui-css/semantic.css' },
    { from: 'node_modules/semantic-ui-css/themes/', to: 'vendor/semantic-ui-css/themes/' },
  ]),
  new HtmlWebpackIncludeAssetsPlugin({
    assets: [
      'vendor/react/dist/react.js',
      'vendor/react-dom/dist/react-dom.js',
      'vendor/semantic-ui-css/semantic.css',
    ],
  }),
],
externals: {
  react: 'React',
  'react-dom': 'ReactDOM',
  'semantic-ui-css': null,
},
```

with the shorter and less redundant:

```js
plugins: [
  new HtmlWebpackPlugin({
    filename: 'index.html',
    template: 'src/index.html',
  }),
  new HtmlWebpackExternalsPlugin({
    externals: [
      { module: 'react', entry: 'dist/react.js', global: 'React' },
      { module: 'react-dom', entry: 'dist/react-dom.js', global: 'ReactDOM' },
      { module: 'semantic-ui-css', entry: 'semantic.css', supplements: ['themes/'] },
    ],
  }),
],
```

As well as supporting CDNs and a few other things.