### PR TITLE
Allow for optionally disabling the title tag

### DIFF
--- a/default_index.ejs
+++ b/default_index.ejs
@@ -2,7 +2,9 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <% if (htmlWebpackPlugin.options.title != null) { %>
     <title><%= htmlWebpackPlugin.options.title %></title>
+    <% } %>
   </head>
   <body>
   </body>


### PR DESCRIPTION
**Changes**
This PR wraps the title tag in the default template with a conditional that will only add the title tag if `htmlWebpackPlugin.options.title` is _not_ equal to `null` or `undefined`.

**Use Case**
I'm building a project with a loader that injects HTML into the page, including the title tag in some places, and am using `html-wepback-plugin` to auto-generate a basic index.html page with that script included. It works fantastically except that my injected title tag isn't being respected because there is already one embedded by this plugin. This change allows you to optionally disable the addition of that title tag so an injected one is respected.

**Other Questions**
I'm consistently getting 11 tests failing on my local installation even with no changes to any files and after I've run `yarn link` and `yarn link html-webpack-plugin` in the directory. Is this expected? Is there something else I'm supposed to do?

Thanks!
Garrett