### PR TITLE
Test for the js extension before creating the script tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -471,7 +471,10 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
  */
 HtmlWebpackPlugin.prototype.generateAssetTags = function (assets) {
   // Turn script files into script tags
-  var scripts = assets.js.map(function (scriptPath) {
+  var js = assets.js.filter(function (scriptPath) {
+    return /.js($|\?)/.test(scriptPath);
+  });
+  var scripts = js.map(function (scriptPath) {
     return {
       tagName: 'script',
       closeTag: true,


### PR DESCRIPTION
I think it can be a good thing to check if the generated script tag is containing a js file (it is done for css files a few lines up).