### PR TITLE
Reference lodash loader by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ and favicon files into the markup.
 plugins: [
   new HtmlWebpackPlugin({
     title: 'Custom template',
-    template: 'my-index.ejs', // Load a custom template (ejs by default see the FAQ for details)
+    template: 'my-index.html', // Load a custom template (lodash by default see the FAQ for details)
   })
 ]
 ```
 
-`my-index.ejs`:
+`my-index.html`:
 
 ```html
 <!DOCTYPE html>

--- a/docs/template-option.md
+++ b/docs/template-option.md
@@ -19,18 +19,18 @@ There are three ways to set the loader:
 
 ## 1) Don't set any loader
 
-By default (if you don't specify any loader in any way) a [fallback ejs loader](https://github.com/ampedandwired/html-webpack-plugin/blob/master/lib/loader.js) kicks in.
+By default (if you don't specify any loader in any way) a [fallback lodash loader](https://github.com/ampedandwired/html-webpack-plugin/blob/master/lib/loader.js) kicks in.
 
 ```js
 {
   plugins: [
     new HtmlWebpackPlugin({
-      template: 'src/index.ejs'
+      template: 'src/index.html'
     })
   ]
 }
 ```
-It is a good idea to use `.ejs` instead of `.html` so you do not unexpectedly trigger another loader.
+Be aware, using `.html` as your template extention may unexpectedly trigger another loader.
 
 ## 2) Setting a loader directly for the template
 


### PR DESCRIPTION
Hello!

It came to my attention that the default loader was being referred to as a ejs loader, when in fact it is a loadsh loader. The syntaxes for both look almost identical, which made it harder to realize what the difference was.

I'm not super fond of the wording I came up with to modify the docs, so I'd be open to other suggestions.

Let me know if this looks good.