### PR TITLE
Cache chunks result between multiple entry point html page

### DIFF
--- a/index.js
+++ b/index.js
@@ -665,7 +665,7 @@ HtmlWebpackPlugin.prototype.applyPluginsAsyncWaterfall = function (compilation) 
 HtmlWebpackPlugin.prototype.getAllChunks = function (compilation) {
   var allChunks = hashToChunksMap[compilation.hash];
   if (!allChunks) {
-    allChunks = compilation.getStats().toJSON().chunks;
+    allChunks = compilation.getStats().toJson().chunks;
     hashToChunksMap[compilation.hash] = allChunks;
   }
   return allChunks;

--- a/index.js
+++ b/index.js
@@ -668,7 +668,7 @@ HtmlWebpackPlugin.prototype.getAllChunks = function (compilation) {
     allChunks = compilation.getStats().toJSON().chunks;
     hashToChunksMap[compilation.hash] = allChunks;
   }
-  return allChunks
+  return allChunks;
 };
 
 module.exports = HtmlWebpackPlugin;

--- a/index.js
+++ b/index.js
@@ -664,7 +664,7 @@ HtmlWebpackPlugin.prototype.applyPluginsAsyncWaterfall = function (compilation) 
  */
 HtmlWebpackPlugin.prototype.getAllChunks = function (compilation) {
   var allChunks = hashToChunksMap[compilation.hash];
-  if(!allChunks){
+  if (!allChunks) {
     allChunks = compilation.getStats().toJSON().chunks;
     hashToChunksMap[compilation.hash] = allChunks;
   }

--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ var chunkSorter = require('./lib/chunksorter.js');
 Promise.promisifyAll(fs);
 
 /**
- * Cache chunks result between multiple entry point html page
+ * Cache compilation stats between multiple entry point html page
  */
-var hashToChunksMap = {};
+var compilationHashToStatsMap = {};
 
 function HtmlWebpackPlugin (options) {
   // Default options
@@ -70,7 +70,7 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
   compiler.plugin('emit', function (compilation, callback) {
     var applyPluginsAsyncWaterfall = self.applyPluginsAsyncWaterfall(compilation);
     // Get all chunks
-    var allChunks = self.getAllChunks(compilation);
+    var allChunks = self.getCompilationStats(compilation).chunks;
     // Filter chunks (options.chunks and options.excludeCHunks)
     var chunks = self.filterChunks(allChunks, self.options.chunks, self.options.excludeChunks);
     // Sort chunks
@@ -257,7 +257,7 @@ HtmlWebpackPlugin.prototype.executeTemplate = function (templateFunction, chunks
     .then(function () {
       var templateParams = {
         compilation: compilation,
-        webpack: compilation.getStats().toJson(),
+        webpack: self.getCompilationStats(compilation),
         webpackConfig: compilation.options,
         htmlWebpackPlugin: {
           files: assets,
@@ -658,17 +658,15 @@ HtmlWebpackPlugin.prototype.applyPluginsAsyncWaterfall = function (compilation) 
 };
 
 /**
- * Get all chunks from compilation
- * @param compilation
- * @return {Array}
+ * Get stats from compilation
  */
-HtmlWebpackPlugin.prototype.getAllChunks = function (compilation) {
-  var allChunks = hashToChunksMap[compilation.hash];
-  if (!allChunks) {
-    allChunks = compilation.getStats().toJson().chunks;
-    hashToChunksMap[compilation.hash] = allChunks;
+HtmlWebpackPlugin.prototype.getCompilationStats = function (compilation) {
+  var stats = compilationHashToStatsMap[compilation.hash];
+  if (!stats) {
+    stats = compilation.getStats().toJson();
+    compilationHashToStatsMap[compilation.hash] = stats;
   }
-  return allChunks;
+  return stats;
 };
 
 module.exports = HtmlWebpackPlugin;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "html-webpack-plugin",
-  "version": "2.30.1",
+  "name": "@yued/html-webpack-plugin",
+  "version": "2.30.2",
   "description": "Simplifies creation of HTML files to serve your webpack bundles",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "html-webpack-plugin",
+  "name": "@yunke/html-webpack-plugin",
   "version": "2.30.2",
   "description": "Simplifies creation of HTML files to serve your webpack bundles",
   "main": "index.js",
@@ -9,7 +9,6 @@
     "lib/"
   ],
   "scripts": {
-    "prepublish": "npm run test",
     "pretest": "semistandard",
     "build-examples": "node examples/build-examples.js",
     "test": "jasmine"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@yunke/html-webpack-plugin",
-  "version": "2.30.2",
+  "name": "html-webpack-plugin",
+  "version": "2.30.1",
   "description": "Simplifies creation of HTML files to serve your webpack bundles",
   "main": "index.js",
   "files": [
@@ -9,6 +9,7 @@
     "lib/"
   ],
   "scripts": {
+    "prepublish": "npm run test",
     "pretest": "semistandard",
     "build-examples": "node examples/build-examples.js",
     "test": "jasmine"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@yued/html-webpack-plugin",
+  "name": "html-webpack-plugin",
   "version": "2.30.2",
   "description": "Simplifies creation of HTML files to serve your webpack bundles",
   "main": "index.js",


### PR DESCRIPTION
In some time the method `compilation.getStats().toJson()`  take long.
At my project, it takes about 1 to 3s, and I have 155 pages, it will take 155 to 460s total, too slow.
Cache the chunks result between entry points, it will reduce a lot of time.
``` js
compiler.plugin('emit', function (compilation, callback) {
    //...
    // Get all chunks
    var allChunks = compilation.getStats().toJson().chunks;
    //....
}
```

``` js
/**
 * Cache chunks result between multiple entry point html page
 */
var hashToChunksMap = {};
//...
compiler.plugin('emit', function (compilation, callback) {
    //...
    // Get all chunks
    var allChunks = self.getAllChunks(compilation);
    //....
}
//....
/**
 * Get all chunks from compilation
 * @param compilation
 * @return {Array}
 */
HtmlWebpackPlugin.prototype.getAllChunks = function (compilation) {
  var allChunks = hashToChunksMap[compilation.hash];
  if (!allChunks) {
    allChunks = compilation.getStats().toJson().chunks;
    hashToChunksMap[compilation.hash] = allChunks;
  }
  return allChunks;
};
```
