### PR TITLE
Refactor manual chunksSortMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Allowed values are as follows:
 - `cache`: `true | false` if `true` (default) try to emit the file only if it was changed.
 - `showErrors`: `true | false` if `true` (default) errors details will be written into the HTML page.
 - `chunks`: Allows you to add only some chunks (e.g. only the unit-test chunk)
-- `chunksSortMode`: Allows to control how chunks should be sorted before they are included to the html. Allowed values: 'none' | 'auto' | 'dependency' |'manual' | {function} - default: 'auto'
+- `chunksSortMode`: Allows to control how chunks should be sorted before they are included to the html. Allowed values: 'none' | 'auto' | 'dependency' | 'manual' - by specifiying the order via `chunks` | {function} - default: 'auto'
 - `excludeChunks`: Allows you to skip some chunks (e.g. don't add the unit-test chunk)
 - `xhtml`: `true | false` If `true` render the `link` tags as self-closing, XHTML compliant. Default is `false`
 

--- a/lib/chunksorter.js
+++ b/lib/chunksorter.js
@@ -105,7 +105,7 @@ module.exports.manual = function (chunks, manualSortOrder) {
   var whitelistedChunksMapByName = util.createLookupObjectFor(whitelistedChunkToSort, util.chunkByName);
 
   // sort the chunks by using the lookup object
-  return _manualSortOrder.map(function (chunkName) { return whitelistedChunksMapByName[chunkName]; })
+  return _manualSortOrder.map(function (chunkName) { return whitelistedChunksMapByName[chunkName]; });
 };
 
 /**

--- a/lib/chunksorter.js
+++ b/lib/chunksorter.js
@@ -2,6 +2,7 @@
 
 var toposort = require('toposort');
 var _ = require('lodash');
+var util = require('./util');
 
 /*
   Sorts dependencies between chunks by their "parents" attribute.
@@ -81,25 +82,30 @@ module.exports.none = function (chunks) {
 };
 
 /**
- * Sort manually by the chunks
+ * Sorts the chunks manually by using the `manualSortOrder` param.
+ *
  * @param  {Array} chunks the chunks to sort
- * @return {Array} The sorted chunks
+ * @param  {Array} manualSortOrder the manually specified chunk order (should contain the chunk names)
+ * @return {Array} the sorted chunks as specified by the `manualSortOrder`.
  */
-module.exports.manual = function (chunks, specifyChunks) {
-  var chunksResult = [];
-  var filterResult = [];
-  if (Array.isArray(specifyChunks)) {
-    for (var i = 0; i < specifyChunks.length; i++) {
-      filterResult = chunks.filter(function (chunk) {
-        if (chunk.names[0] && chunk.names[0] === specifyChunks[i]) {
-          return true;
-        }
-        return false;
-      });
-      filterResult.length > 0 && chunksResult.push(filterResult[0]);
-    }
-  }
-  return chunksResult;
+module.exports.manual = function (chunks, manualSortOrder) {
+  var _chunks = chunks || [];
+  var _manualSortOrder = manualSortOrder || [];
+
+  // create a lookup object for the chunks that need to be sorted
+  var manualSortOrderMapByValue = util.createLookupObjectFor(_manualSortOrder, util.arrayByValue);
+
+  // filter out chunks which are not given in the manual sort order
+  var whitelistedChunkToSort = _chunks.filter(function (chunk) {
+    var chunkName = util.getNameForChunk(chunk);
+    return manualSortOrderMapByValue[chunkName];
+  });
+
+  // create a lookup object for the chunks which need to be sorted
+  var whitelistedChunksMapByName = util.createLookupObjectFor(whitelistedChunkToSort, util.chunkByName);
+
+  // sort the chunks by using the lookup object
+  return _manualSortOrder.map(function (chunkName) { return whitelistedChunksMapByName[chunkName]; })
 };
 
 /**

--- a/lib/chunksorter.js
+++ b/lib/chunksorter.js
@@ -96,13 +96,13 @@ module.exports.manual = function (chunks, manualSortOrder) {
   var manualSortOrderMapByValue = util.createLookupObjectFor(_manualSortOrder, util.arrayByValue);
 
   // filter out chunks which are not given in the manual sort order
-  var whitelistedChunkToSort = _chunks.filter(function (chunk) {
+  var whitelistedChunks = _chunks.filter(function (chunk) {
     var chunkName = util.getNameForChunk(chunk);
     return manualSortOrderMapByValue[chunkName];
   });
 
   // create a lookup object for the chunks which need to be sorted
-  var whitelistedChunksMapByName = util.createLookupObjectFor(whitelistedChunkToSort, util.chunkByName);
+  var whitelistedChunksMapByName = util.createLookupObjectFor(whitelistedChunks, util.chunkByName);
 
   // sort the chunks by using the lookup object
   return _manualSortOrder.map(function (chunkName) { return whitelistedChunksMapByName[chunkName]; });

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,8 +3,7 @@
 var _assign = require('lodash/assign');
 
 (function () {
-
-  function createLookupObjectFor(array, reducer) {
+  function createLookupObjectFor (array, reducer) {
     return array.reduce(reducer, {});
   }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var _assign = require('lodash/assign');
+
+(function () {
+
+  function createLookupObjectFor(array, reducer) {
+    return array.reduce(reducer, {});
+  }
+
+  function identity (value) {
+    return value;
+  }
+
+  function getNameForChunk (chunk) {
+    return chunk.names[0];
+  }
+
+  function toLookupObjectBy (keyPropertyExtractor, accumulator, currentValue, currentIndex) {
+    var currentValueKey = keyPropertyExtractor(currentValue, currentIndex);
+    var currentArrayItemObject = {};
+    currentArrayItemObject[currentValueKey] = currentValue;
+    return _assign(accumulator, currentArrayItemObject);
+  }
+
+  var arrayByValue = toLookupObjectBy.bind(null, identity);
+  var chunkByName = toLookupObjectBy.bind(null, getNameForChunk);
+
+  module.exports.createLookupObjectFor = createLookupObjectFor;
+  module.exports.getNameForChunk = getNameForChunk;
+  module.exports.identity = identity;
+  module.exports.arrayByValue = arrayByValue;
+  module.exports.chunkByName = chunkByName;
+})();


### PR DESCRIPTION
Refactor manual chunksSortMode by creating a lookup object for the chunks by their name to later avoid iterating through the chunks array in a nested for loop.

Add an additional comment to the README section for manual chunkSortMode.