### PR TITLE
Reduce stats requested at emit and optionally remove from template

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ function HtmlWebpackPlugin (options) {
     chunks: 'all',
     excludeChunks: [],
     title: 'Webpack App',
-    xhtml: false
+    xhtml: false,
+    templateStats: true
   }, options);
 }
 
@@ -64,8 +65,24 @@ HtmlWebpackPlugin.prototype.apply = function (compiler) {
 
   compiler.plugin('emit', function (compilation, callback) {
     var applyPluginsAsyncWaterfall = self.applyPluginsAsyncWaterfall(compilation);
-    // Get all chunks
-    var allChunks = compilation.getStats().toJson().chunks;
+    // Get chunks info as json
+    // Note: we're excluding stuff that we don't need to improve toJson serialization speed.
+    var chunkOnlyConfig = {
+      assets: false,
+      cached: false,
+      children: false,
+      chunks: true,
+      chunkModules: false,
+      chunkOrigins: false,
+      errorDetails: false,
+      hash: false,
+      modules: false,
+      reasons: false,
+      source: false,
+      timings: false,
+      version: false
+    };
+    var allChunks = compilation.getStats().toJson(chunkOnlyConfig).chunks;
     // Filter chunks (options.chunks and options.excludeCHunks)
     var chunks = self.filterChunks(allChunks, self.options.chunks, self.options.excludeChunks);
     // Sort chunks
@@ -252,7 +269,7 @@ HtmlWebpackPlugin.prototype.executeTemplate = function (templateFunction, chunks
     .then(function () {
       var templateParams = {
         compilation: compilation,
-        webpack: compilation.getStats().toJson(),
+        webpack: self.options.templateStats ? compilation.getStats().toJson() : undefined,
         webpackConfig: compilation.options,
         htmlWebpackPlugin: {
           files: assets,


### PR DESCRIPTION
At Trello we have been dealing with some build speed issues related to building multiple locale specific HTML files.  These issues are similar to what's described [here](https://github.com/jantimon/html-webpack-plugin/issues/724).

After instrumenting this plugin, I found that the majority of the time spent here is in the two `toJson` calls that are done.  This change modifies the stats we request in the initial `toJson` call in the emit callback and also provides a constructor property that allows plugin users to opt out of the `toJson` call that is done in the template handler.  In our case, we didn't need access to that `webpack` variable in our template, and therefore did not need the overhead of the `toJson` call.