### PR TITLE
feat(template): support custom template params

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,7 +250,7 @@ HtmlWebpackPlugin.prototype.executeTemplate = function (templateFunction, chunks
   return Promise.resolve()
     // Template processing
     .then(function () {
-      var templateParams = {
+      var templateParams = _.extend(self.options.templateParams || {}, {
         compilation: compilation,
         webpack: compilation.getStats().toJson(),
         webpackConfig: compilation.options,
@@ -258,7 +258,7 @@ HtmlWebpackPlugin.prototype.executeTemplate = function (templateFunction, chunks
           files: assets,
           options: self.options
         }
-      };
+      });
       var html = '';
       try {
         html = templateFunction(templateParams);


### PR DESCRIPTION
This allows the user to inject custom variables to be used in the template interpolation, e.g. simplifying `webpackConfig.output.publicPath` to something shorter.

Docs/tests are not included, but if this sounds like a good idea I can add those upon request.