### PR TITLE
Fix build when the first chunk file is a JSON manifest

### DIFF
--- a/index.js
+++ b/index.js
@@ -443,7 +443,11 @@ HtmlWebpackPlugin.prototype.htmlWebpackPluginAssets = function (compilation, chu
 
     // Webpack outputs an array for each chunk when using sourcemaps
     // But we need only the entry file
-    var entry = chunkFiles[0];
+    var entry = chunkFiles.filter(function (chunkFile) {
+      // Sometimes the first chunk isn’t the entry file but a JSON manifest.
+      // We must filter out non-JS files from the list to account for such cases.
+      return /\.js($|\?)/.test(chunkFile);
+    })[0];
     assets.chunks[chunkName].size = chunk.size;
     assets.chunks[chunkName].entry = entry;
     assets.chunks[chunkName].hash = chunk.hash;


### PR DESCRIPTION
Hi, thanks for the awesome plugin!

Recently our build broke after a stack upgrade. It turns out one of the chunks comes with the `files` property looking like this:

```json
[
  "manifest.json",
  "vendor.8de0754649cf8ee08d2bcefea840020d52c818d2.b971ea180336280f6e10.js",
  "vendor.8de0754649cf8ee08d2bcefea840020d52c818d2.b971ea180336280f6e10.js.map"
]
```

which leads to a wonky `<script type="test/javascript" src=".../manifest.json"></script>` being built into the HTML. This PR fixes it.