### PR TITLE
docs(README): update template variables list

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,11 @@ The following variables are available in the template:
 - `webpackConfig`: the webpack configuration that was used for this compilation. This
   can be used, for example, to get the `publicPath` (`webpackConfig.output.publicPath`).
 
+- `compilation`: the webpack [compilation](https://webpack.js.org/api/compilation/) object.
+  This can be used, for example, to get the contents of processed assets and inline them
+  directly in the page, through `compilation.assets[...].source()`
+  (see [the inline template example](examples/inline/template.jade)).
+
 
 Filtering chunks
 ----------------


### PR DESCRIPTION
Documentation didn't mention `compilation` variable available in templates, which is crucial for inlining assets in html, even though there is an example in the repo using this variable.