### PR TITLE
expected behavior: options.template could be a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -609,6 +609,12 @@ HtmlWebpackPlugin.prototype.createHtmlTag = function (tagDefinition) {
  * Helper to return the absolute template path with a fallback loader
  */
 HtmlWebpackPlugin.prototype.getFullTemplatePath = function (template, context) {
+
+  // If template is a function, run the function and use its value
+  if (typeof(template) === 'function') {
+    template = template()
+  }
+
   // If the template doesn't use a loader use the lodash template loader
   if (template.indexOf('!') === -1) {
     template = require.resolve('./lib/loader.js') + '!' + path.resolve(context, template);

--- a/index.js
+++ b/index.js
@@ -609,10 +609,9 @@ HtmlWebpackPlugin.prototype.createHtmlTag = function (tagDefinition) {
  * Helper to return the absolute template path with a fallback loader
  */
 HtmlWebpackPlugin.prototype.getFullTemplatePath = function (template, context) {
-
   // If template is a function, run the function and use its value
-  if (typeof(template) === 'function') {
-    template = template()
+  if (typeof template === 'function') {
+    template = template();
   }
 
   // If the template doesn't use a loader use the lodash template loader


### PR DESCRIPTION
Hello,

I'm expected, that the config property "template" of the html-webpack-plugin-config could also be a function delivering a string. For example the "entry"-config option of webpack can be either a string or a function.

So, to be coherent, I think this plugin script should support this too.
In my case, it enables me to make the webpack configuration be more dynamic.