### PR TITLE
allow to specify regexp as included or excluded chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -369,6 +369,21 @@ class HtmlWebpackPlugin {
   }
 
   /**
+   * Helper to filter chunk
+   */
+  testChunk (chunkName, test, shouldInclude) {
+    if (Array.isArray(test) && shouldInclude === (test.indexOf(chunkName) !== -1)) {
+      return true;
+    }
+
+    if (test instanceof RegExp && shouldInclude === test.test(chunkName)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
    * Return all chunks from the compilation result which match the exclude and include filters
    */
   filterChunks (chunks, includedChunks, excludedChunks) {
@@ -387,11 +402,11 @@ class HtmlWebpackPlugin {
         return false;
       }
       // Skip if the chunks should be filtered and the given chunk was not added explicity
-      if (Array.isArray(includedChunks) && includedChunks.indexOf(chunkName) === -1) {
+      if (this.testChunk(chunkName, includedChunks, false)) {
         return false;
       }
       // Skip if the chunks should be filtered and the given chunk was excluded explicity
-      if (Array.isArray(excludedChunks) && excludedChunks.indexOf(chunkName) !== -1) {
+      if (this.testChunk(chunkName, excludedChunks, true)) {
         return false;
       }
       // Add otherwise

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -348,6 +348,36 @@ describe('HtmlWebpackPlugin', function () {
     }, ['<script type="text/javascript" src="app_bundle.js"'], null, done);
   });
 
+  it('allows you to inject a specified asset by regular expression into a given html file', function (done) {
+    testHtmlPlugin({
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js'),
+        util: path.join(__dirname, 'fixtures/util.js'),
+        'app~commons': path.join(__dirname, 'fixtures/util.js'),
+        'util~commons': path.join(__dirname, 'fixtures/util.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          chunksSortMode: function (a, b) {
+            if (a.names[0] < b.names[0]) {
+              return 1;
+            }
+            if (a.names[0] > b.names[0]) {
+              return -1;
+            }
+            return 0;
+          },
+          chunks: /app/
+        })
+      ]
+    }, [
+      /<script type="text\/javascript" src="app~commons_bundle.js">.+<script type="text\/javascript" src="app_bundle.js">/], null, done);
+  });
+
   it('allows you to inject a specified asset into a given html file', function (done) {
     testHtmlPlugin({
       entry: {
@@ -364,6 +394,36 @@ describe('HtmlWebpackPlugin', function () {
         template: path.join(__dirname, 'fixtures/plain.html')
       })]
     }, ['<script type="text/javascript" src="app_bundle.js"'], null, done);
+  });
+
+  it('allows you to inject a specified asset by regular expression into a given html file', function (done) {
+    testHtmlPlugin({
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js'),
+        util: path.join(__dirname, 'fixtures/util.js'),
+        'app~commons': path.join(__dirname, 'fixtures/util.js'),
+        'util~commons': path.join(__dirname, 'fixtures/util.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          chunksSortMode: function (a, b) {
+            if (a.names[0] < b.names[0]) {
+              return 1;
+            }
+            if (a.names[0] > b.names[0]) {
+              return -1;
+            }
+            return 0;
+          },
+          excludeChunks: /util/
+        })
+      ]
+    }, [
+      /<script type="text\/javascript" src="app~commons_bundle.js">.+<script type="text\/javascript" src="app_bundle.js">/], null, done);
   });
 
   it('allows you to use chunkhash with asset into a given html file', function (done) {


### PR DESCRIPTION
I write this feature because of new `splitChunks` naming in webpack 4. It makes common chunks for several chunks and names them as `chun1~chunk2`.  So, if I want to inject only chunks which have code for my `chunk1` I added this change.