### PR TITLE
docs(readme): fix options table

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Allowed values are as follows
 |**[`cache`](#)**|`{Boolean}`|`true`|Emit the file only if it was changed|
 |**[`showErrors`](#)**|`{Boolean}`|`true`|Errors details will be written into the HTML page|
 |**[`chunks`](#)**|`{?}`|`?`|Allows you to add only some chunks (e.g only the unit-test chunk)|
-|**[`chunksSortMode`](#plugins)**|`{String/|Function}`|`auto`|Allows to control how chunks should be sorted before they are included to the HTML. Allowed values are `'none' | 'auto' | 'dependency' | 'manual' | {Function}`|
+|**[`chunksSortMode`](#plugins)**|`{String\|Function}`|`auto`|Allows to control how chunks should be sorted before they are included to the HTML. Allowed values are `'none' \| 'auto' \| 'dependency' \| 'manual' \| {Function}`|
 |**[`excludeChunks`](#)**|`{String}`|``|Allows you to skip some chunks (e.g don't add the unit-test chunk)|
 |**[`xhtml`](#)**|`{Boolean}`|`false`|If `true` render the `link` tags as self-closing (XHTML compliant)|
 


### PR DESCRIPTION
apparently `|` in code blocks in tables need to be escaped these days…