### PR TITLE
Add a note about ordering first

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ If you have multiple `webpack` entry points, they will all be included with `scr
 If you have any CSS assets in webpack's output (for example, CSS extracted with the [ExtractTextPlugin](https://github.com/webpack/extract-text-webpack-plugin))
 then these will be included with `<link>` tags in the HTML head.
 
+If you have plugins that make use of it, `html-webpack-plugin` should be ordered first before any of the integrated plugins.
+
 <h2 align="center">Options</h2>
 
 You can pass a hash of configuration options to `html-webpack-plugin`.


### PR DESCRIPTION
Per @thelarkinn's suggestion, it is necessary to order `html-webpack-plugin` first before other plugins that make use of it.