### PR TITLE
fix(entries): do not ignore JS if there is also CSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -453,13 +453,13 @@ class HtmlWebpackPlugin {
       }
 
       // Webpack outputs an array for each chunk when using sourcemaps
-      // But we need only the initial entry file in case it is a js file
-      const entry = chunkFiles[0];
-      if (/.js($|\?)/.test(entry)) {
+      // or when one chunk hosts js and css simultaneously
+      const js = chunkFiles.find(chunkFile => /.js($|\?)/.test(chunkFile));
+      if (js) {
         assets.chunks[chunkName].size = chunk.size;
-        assets.chunks[chunkName].entry = entry;
+        assets.chunks[chunkName].entry = js;
         assets.chunks[chunkName].hash = chunk.hash;
-        assets.js.push(entry);
+        assets.js.push(js);
       }
 
       // Gather all css files


### PR DESCRIPTION
follow up to commit 0348d6b

Upgrading to Webpack 4 (possibly by switching from [extract-text-webpack-plugin](https://github.com/webpack-contrib/extract-text-webpack-plugin) to [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin) I ended up with chunks that look like

```js
{
  "id": 17,
  "rendered": true,
  "initial": true,
  "entry": false,
  "size": 1014209,
  "names": [
    "app"
  ],
  "files": [
    "static/css/app.ebfdfd28fd7984cf790d.css",
    "static/js/app.ebfdfd28fd7984cf790d.js"
  ],
  "hash": "ebfdfd28fd7984cf790d",
  "siblings": [
    // …
  ],
  "parents": [],
  "children": [
    // …
  ]
}
```

which currently translates to the following `htmlWebpackPlugin.files`:

```js
{
  "publicPath": "/gustav/",
  "chunks": {
    "app": {
      "css": ["/gustav/static/css/app.ebfdfd28fd7984cf790d.css"]
    }
  },
  "js": [],
  "css": ["/gustav/static/css/app.ebfdfd28fd7984cf790d.css"]
}
```

This PR changes the way how a chunk is considered to contain JS or not in order to get `htmlWebpackPlugin.files` to output:

```js
{
  "publicPath": "/gustav/",
  "chunks": {
    "app": {
      "size": 1014209,
      "entry": "/gustav/static/js/app.ebfdfd28fd7984cf790d.js",
      "hash": "ebfdfd28fd7984cf790d",
      "css": ["/gustav/static/css/app.ebfdfd28fd7984cf790d.css"]
    }
  },
  "js": ["/gustav/static/js/app.ebfdfd28fd7984cf790d.js"],
  "css": ["/gustav/static/css/app.ebfdfd28fd7984cf790d.css"]
}
```