### PR TITLE
Add entry config to get chunks of entrypoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Allowed values are as follows
 
 |Name|Type|Default|Description|
 |:--:|:--:|:-----:|:----------|
+|**[`entry`](#)**|`{String}`|``|The entry to get chunks for entrypoint|
 |**[`title`](#)**|`{String}`|``|The title to use for the generated HTML document|
 |**[`filename`](#)**|`{String}`|`'index.html'`|The file to write the HTML to. Defaults to `index.html`. You can specify a subdirectory here too (eg: `assets/admin.html`)|
 |**[`template`](#)**|`{String}`|``|`webpack` require path to the template. Please see the [docs](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md) for details|

--- a/index.js
+++ b/index.js
@@ -108,7 +108,9 @@ class HtmlWebpackPlugin {
       };
       const allChunks = compilation.getStats().toJson(chunkOnlyConfig).chunks;
       // Filter chunks (options.chunks and options.excludeCHunks)
-      let chunks = self.filterChunks(allChunks, self.options.chunks, self.options.excludeChunks);
+      let tempChunks = compilation.entrypoints.get(self.options.entry).chunks.map(c => c.name);
+
+      let chunks = self.filterChunks(allChunks, tempChunks, self.options.excludeChunks);
       // Sort chunks
       chunks = self.sortChunks(chunks, self.options.chunksSortMode, compilation);
       // Let plugins alter the chunks and the chunk sorting


### PR DESCRIPTION
The feature is to resolve  the problem of the common chunks  inserting HTML. 
For example:
webpack config
```
module.exports = {
      entry: {
          index:  './src/index/main.js'
      },
      optimization: {
        splitChunks: {
            cacheGroups: {
                commons: {
                    chunks: 'initial',
                    minChunks: 2,
                    maxInitialRequests: 5, // The default limit is too small to showcase the effect
                    minSize: 0 // This is example is too small to create commons chunks
                },
                vendor: {
                    test: /node_modules/,
                    chunks: 'initial',
                    name: 'vendor',
                    priority: 10,
                    enforce: true
                }
            }
        }
    },
    plugins: [
        new HtmlWebpackPlugin({
          // Required
          entry: 'index'
          inject: true,
          template: './src/index/index.ejs',
}
```