### PR TITLE
fix(loader): Allow to add new template parameters

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -25,28 +25,11 @@ module.exports = function (source) {
   //
   // Get templating options
   const options = this.query !== '' ? loaderUtils.parseQuery(this.query) : {};
-  // Webpack 2 does not allow with() statements, which lodash templates use to unwrap
-  // the parameters passed to the compiled template inside the scope. We therefore
-  // need to unwrap them ourselves here. This is essentially what lodash does internally
-  // To tell lodash it should not use with we set a variable
   const template = _.template(source, _.defaults(options, { variable: 'data' }));
-  // All templateVariables which should be available
-  // @see HtmlWebpackPlugin.prototype.executeTemplate
-  const templateVariables = [
-    'compilation',
-    'webpack',
-    'webpackConfig',
-    'htmlWebpackPlugin'
-  ];
   // Require !!lodash - using !! will disable all loaders (e.g. babel)
   return 'var _ = require(' + loaderUtils.stringifyRequest(this, '!!' + require.resolve('lodash')) + ');' +
-    'module.exports = function (templateParams) {' +
-      // Declare the template variables in the outer scope of the
-      // lodash template to unwrap them
-      templateVariables.map(function (variableName) {
-        return 'var ' + variableName + ' = templateParams.' + variableName;
-      }).join(';') + ';' +
+    'module.exports = function (templateParams) { with(templateParams) {' +
       // Execute the lodash template
       'return (' + template.source + ')();' +
-    '}';
+    '}}';
 };


### PR DESCRIPTION
Tries to revert a change which was done for webpack 2 to be compatible with use strict:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode