### PR TITLE
Set min node.js version to 6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "homepage": "https://github.com/jantimon/html-webpack-plugin",
   "repository": "https://github.com/jantimon/html-webpack-plugin.git",
   "engines": {
-    "node": ">=6.11.5"
+    "node": ">=6.9"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
In https://github.com/jantimon/html-webpack-plugin/pull/861 support for nodejs < 6 was dropped. However, the minimal version was to 6.11.5 for no clear reason. This excludes version v6.11.4 from current Ubuntu 17.10 as well as version 6.10.3 running on AWS Lambda.

If features newer then 6.0.0 are needed, we should only set the minor version, not the patch level, e.g. 6.11.0 instead of 6.11.5 because Linux distributions often apply patches to a fixed version, so v6.11.4 on Ubuntu is likely to have all security fixes that are in 6.11.5.