### PR TITLE
Add -loader suffix to handlerbars

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Please note that this will also happen if you specifiy the html-loader and use `
 ```js
 module: {
   loaders: [
-    { test: /\.hbs$/, loader: "handlebars" }
+    { test: /\.hbs$/, loader: "handlebars-loader" }
   ]
 },
 plugins: [


### PR DESCRIPTION
It's no longer allowed to omit the '-loader' suffix when using loaders. You need to specify 'handlebars-loader' instead of 'handlebars', see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed