### PR TITLE
Update README with Tapable.hooks example

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,11 +289,11 @@ plugins: [
 
 To allow other [plugins](https://github.com/webpack/docs/wiki/plugins) to alter the HTML this plugin executes the following events:
 
-#### `Sync`
+#### `SyncWaterfallHook`
 
 * `htmlWebpackPluginAlterChunks`
 
-#### `Async`
+#### `AsyncSeriesWaterfallHook`
 
 * `htmlWebpackPluginBeforeHtmlGeneration`
 * `htmlWebpackPluginBeforeHtmlProcessing`


### PR DESCRIPTION
Webpack v4 deprecates the use of `Tapable.plugin()`. This plugin was updated to use `Tapable.hooks`, but the example in the README was not.