### PR TITLE
added includeSiblingChunks for webpack4's optimization.splitChunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Allowed values are as follows
 |**[`cache`](#)**|`{Boolean}`|`true`|Emit the file only if it was changed|
 |**[`showErrors`](#)**|`{Boolean}`|`true`|Errors details will be written into the HTML page|
 |**[`chunks`](#)**|`{?}`|`?`|Allows you to add only some chunks (e.g only the unit-test chunk)|
+|**[`includeSiblingChunks`](#)**|`{Boolean}`|`false`|Include all other splitted chunks of `chunks` option. (For chunks splitted by webpack4's `optimization.splitChunks`)|
 |**[`chunksSortMode`](#plugins)**|`{String\|Function}`|`auto`|Allows to control how chunks should be sorted before they are included to the HTML. Allowed values are `'none' \| 'auto' \| 'dependency' \| 'manual' \| {Function}`|
 |**[`excludeChunks`](#)**|`{Array.<string>}`|``|Allows you to skip some chunks (e.g don't add the unit-test chunk)|
 |**[`xhtml`](#)**|`{Boolean}`|`false`|If `true` render the `link` tags as self-closing (XHTML compliant)|

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ class HtmlWebpackPlugin {
       cache: true,
       showErrors: true,
       chunks: 'all',
+      includeSiblingChunks: false,
       excludeChunks: [],
       chunksSortMode: 'auto',
       meta: {},
@@ -109,6 +110,10 @@ class HtmlWebpackPlugin {
       const allChunks = compilation.getStats().toJson(chunkOnlyConfig).chunks;
       // Filter chunks (options.chunks and options.excludeCHunks)
       let chunks = self.filterChunks(allChunks, self.options.chunks, self.options.excludeChunks);
+      // Add sibling chunks
+      if (self.options.includeSiblingChunks) {
+        chunks = self.includeSiblingChunks(allChunks, chunks);
+      }
       // Sort chunks
       chunks = self.sortChunks(chunks, self.options.chunksSortMode, compilation);
       // Let plugins alter the chunks and the chunk sorting
@@ -351,6 +356,20 @@ class HtmlWebpackPlugin {
       };
       return basename;
     });
+  }
+
+  /**
+   * Helper to include splitted sibling chunks
+   */
+  includeSiblingChunks (chunks, filteredChunks) {
+    return filteredChunks.reduce((prevChunk, curChunk) => {
+      const siblings = curChunk.siblings;
+      let siblingChunks = [];
+      if (siblings) {
+        siblingChunks = chunks.filter(chunk => siblings.indexOf(chunk.names[0]) !== -1);
+      }
+      return prevChunk.concat(curChunk, siblingChunks);
+    }, []);
   }
 
   /**


### PR DESCRIPTION
This is a quick fix for webpack4's `optimization.splitChunks` issues like https://github.com/jantimon/html-webpack-plugin/issues/878 before the webpack-4 branch is ready.

I've also added `includeSiblingChunks` option as a flag for activating this feature to avoid regression.