### PR TITLE
feat: support ES6 template string in default loader

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -25,7 +25,7 @@ module.exports = function (source) {
   //
   // Get templating options
   const options = this.query !== '' ? loaderUtils.parseQuery(this.query) : {};
-  const template = _.template(source, _.defaults(options, { variable: 'data' }));
+  const template = _.template(source, _.defaults(options, { interpolate: /<%=([\s\S]+?)%>/g, variable: 'data' }));
   // Require !!lodash - using !! will disable all loaders (e.g. babel)
   return 'var _ = require(' + loaderUtils.stringifyRequest(this, '!!' + require.resolve('lodash')) + ');' +
     'module.exports = function (templateParams) { with(templateParams) {' +


### PR DESCRIPTION
Only transpile EJS style `<%= name %>`, Close #950