### PR TITLE
addFileToAssets allow output name override

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,13 +339,17 @@ class HtmlWebpackPlugin {
     })
     .catch(() => Promise.reject(new Error('HtmlWebpackPlugin: could not load file ' + filename)))
     .then(results => {
-      const basename = outputName
-        ? outputName.replace(/\[contenthash]/gi, () => {
-          const hash = crypto.createHash('md5');
-          hash.update(results.source);
-          return hash.digest('hex');
-        })
-        : path.basename(filename);
+      let basename = path.basename(filename);
+      if (outputName != null) {
+        basename = outputName
+          .replace(/\[contenthash]/gi, () => {
+            const hash = crypto.createHash('md5');
+            hash.update(results.source);
+            return hash.digest('hex');
+          })
+          // name without the extension
+          .replace(/\[name]/gi, () => basename.replace(/\.[^/.]+$/, ''));
+      }
       if (compilation.fileDependencies.add) {
         compilation.fileDependencies.add(filename);
       } else {

--- a/index.js
+++ b/index.js
@@ -324,7 +324,7 @@ class HtmlWebpackPlugin {
   /*
    * Pushes the content of the given filename to the compilation assets
    */
-  addFileToAssets (filename, compilation) {
+  addFileToAssets (filename, compilation, outputName) {
     filename = path.resolve(compilation.compiler.context, filename);
     return Promise.all([
       fsStatAsync(filename),
@@ -338,7 +338,7 @@ class HtmlWebpackPlugin {
     })
     .catch(() => Promise.reject(new Error('HtmlWebpackPlugin: could not load file ' + filename)))
     .then(results => {
-      const basename = path.basename(filename);
+      const basename = outputName || path.basename(filename);
       if (compilation.fileDependencies.add) {
         compilation.fileDependencies.add(filename);
       } else {

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const vm = require('vm');
 const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
+const crypto = require('crypto');
 const childCompiler = require('./lib/compiler.js');
 const prettyError = require('./lib/errors.js');
 const chunkSorter = require('./lib/chunksorter.js');
@@ -338,7 +339,13 @@ class HtmlWebpackPlugin {
     })
     .catch(() => Promise.reject(new Error('HtmlWebpackPlugin: could not load file ' + filename)))
     .then(results => {
-      const basename = outputName || path.basename(filename);
+      const basename = outputName
+        ? outputName.replace(/\[contenthash]/gi, () => {
+          const hash = crypto.createHash('md5');
+          hash.update(results.source);
+          return hash.digest('hex');
+        })
+        : path.basename(filename);
       if (compilation.fileDependencies.add) {
         compilation.fileDependencies.add(filename);
       } else {

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -1748,4 +1748,31 @@ describe('HtmlWebpackPlugin', function () {
       })]
     }, [/<head>[\s]*<script type="text\/javascript" src="index_bundle.js"><\/script>[\s]*<\/head\s>/], null, done);
   });
+
+  it('addFileToAssets allows you to override output name of asset', function (done) {
+    const plugin = new HtmlWebpackPlugin();
+    const compilation = {
+      compiler: {
+        context: __dirname
+      },
+      assets: {},
+      fileDependencies: {
+        add (f) { this.files.push(f); },
+        files: []
+      }
+    };
+
+    plugin
+      .addFileToAssets('fixtures/additional_asset.js', compilation, 'foo.[contentHash].js')
+      .then(filename => {
+        const expectedFilename = 'foo.a507be46681ab5fdc64d829da4a0fc92.js';
+        expect(filename).toEqual(expectedFilename);
+        expect(compilation.assets[expectedFilename].source().toString())
+          .toEqual('// Content will be hashed in tests, do not change.\n');
+        expect(compilation.assets[expectedFilename].size())
+          .toEqual(51);
+        expect(compilation.fileDependencies.files).toEqual(['/Users/toby/dev/html-webpack-plugin/spec/fixtures/additional_asset.js']);
+        done();
+      });
+  });
 });

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -1763,9 +1763,9 @@ describe('HtmlWebpackPlugin', function () {
     };
 
     plugin
-      .addFileToAssets('fixtures/additional_asset.js', compilation, 'foo.[contentHash].js')
+      .addFileToAssets('fixtures/additional_asset.js', compilation, '[name].foo.[contentHash].js')
       .then(filename => {
-        const expectedFilename = 'foo.a507be46681ab5fdc64d829da4a0fc92.js';
+        const expectedFilename = 'additional_asset.foo.a507be46681ab5fdc64d829da4a0fc92.js';
         expect(filename).toEqual(expectedFilename);
         expect(compilation.assets[expectedFilename].source().toString())
           .toEqual('// Content will be hashed in tests, do not change.\n');

--- a/spec/BasicSpec.js
+++ b/spec/BasicSpec.js
@@ -1771,7 +1771,7 @@ describe('HtmlWebpackPlugin', function () {
           .toEqual('// Content will be hashed in tests, do not change.\n');
         expect(compilation.assets[expectedFilename].size())
           .toEqual(51);
-        expect(compilation.fileDependencies.files).toEqual(['/Users/toby/dev/html-webpack-plugin/spec/fixtures/additional_asset.js']);
+        expect(compilation.fileDependencies.files).toEqual([`${__dirname}/fixtures/additional_asset.js`]);
         done();
       });
   });

--- a/spec/fixtures/additional_asset.js
+++ b/spec/fixtures/additional_asset.js
@@ -1,0 +1,1 @@
+// Content will be hashed in tests, do not change.


### PR DESCRIPTION
Allows for e.g. including a hash in the output name.