### PR TITLE
feat: Add default viewport meta tag for default template

### DIFF
--- a/examples/default/dist/webpack-4/index.html
+++ b/examples/default/dist/webpack-4/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Webpack App</title>
-  </head>
+  <meta name="viewport" content="width=device-width, initial-scale=1"></head>
   <body>
   <script src="bundle.js"></script></body>
 </html>

--- a/examples/favicon/dist/webpack-4/favicon.html
+++ b/examples/favicon/dist/webpack-4/favicon.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>HtmlWebpackPlugin example</title>
-  <link rel="shortcut icon" href="favicon.ico"><link href="styles.css" rel="stylesheet"></head>
+  <meta name="viewport" content="width=device-width, initial-scale=1"><link rel="shortcut icon" href="favicon.ico"><link href="styles.css" rel="stylesheet"></head>
   <body>
   <script src="bundle.js"></script></body>
 </html>

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -72,7 +72,7 @@ interface HtmlWebpackPluginOptions {
      */
     meta: false // Disable injection
       | {
-          [name: string]: string // name content pair e.g. {viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no'}`
+          [name: string]: string|false // name content pair e.g. {viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no'}`
           | {[attributeName: string]: string|boolean} // custom properties e.g. { name:"viewport" content:"width=500, initial-scale=1" }
       },
     /**


### PR DESCRIPTION
Added a default viewport:

```
<meta name="viewport" content="width=device-width, initial-scale=1">
```

fix  #897, fix #978