### PR TITLE
docs: add 'templateContent' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Allowed values are as follows
 |**[`filename`](#)**|`{String}`|`'index.html'`|The file to write the HTML to. Defaults to `index.html`. You can specify a subdirectory here too (eg: `assets/admin.html`)|
 |**[`template`](#)**|`{String}`|``|`webpack` require path to the template. Please see the [docs](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md) for details|
 |**[`templateParameters`](#)**|`{Boolean\|Object\|Function}`|``| Allows to overwrite the parameters used in the template |
+|**[`templateContent`](#)**|`{String\|Function}`|``|A string that contains (or function that returns) the content of the template. `template` and `templateContent` options **may not both be used**. Overwrites `template` option|
 |**[`inject`](#)**|`{Boolean\|String}`|`true`|`true \|\| 'head' \|\| 'body' \|\| false` Inject all assets into the given `template` or `templateContent`. When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element|
 |**[`favicon`](#)**|`{String}`|``|Adds the given favicon path to the output HTML|
 |**[`meta`](#)**|`{Object}`|`{}`|Allows to inject `meta`-tags. E.g. `meta: {viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no'}`|


### PR DESCRIPTION
Hello!

Noticed this option was missing from docs. Let me know if there are any issues with adding it, or if you'd like the wording changed a bit. 

This plugin is extremely handy by the way! Thanks for maintaining it. 😃 