### PR TITLE
add media-query-plugin to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The `html-webpack-plugin` provides [hooks](https://github.com/jantimon/html-webp
  * [html-webpack-inline-style-plugin](https://github.com/djaax/html-webpack-inline-style-plugin) for inlining styles to HTML elements using [juice](https://github.com/Automattic/juice). Useful for email generation automatisation.
  * [html-webpack-exclude-empty-assets-plugin](https://github.com/KnisterPeter/html-webpack-exclude-empty-assets-plugin) removes empty assets from being added to the html. This fixes some problems with extract-text-plugin with webpack 4.
  * [webpack-concat-plugin](https://github.com/hxlniada/webpack-concat-plugin) for concat and uglify files that needn't to be webpack bundles(for legacy files) and inject to html-webpack-plugin.
+ * [media-query-plugin](https://github.com/SassNinja/media-query-plugin) allows to extract media queries from the CSS and add the extracted files to your template as `<link media='query'>` what still causes a download of the files but reduces the render blocking time.
  
 
 <h2 align="center">Usage</h2>


### PR DESCRIPTION
This PR adds a link to the [media-query-plugin](https://github.com/SassNinja/media-query-plugin) to the docs.
It plays together well with the html-webpack-plugin and provides the extracted files to the template with the query data to let you use something as `<link media='query'>`

I'm aware there's already a similar plugin in the list (link-media-html-webpack-plugin). But its description is wrong (the browser downloads the files always, not conditionally) and it provides less features.

Thus I hope it's ok to add the media-query-plugin, too.