### PR TITLE
Rename contenthash to hashByContent to resolve internal webpack conflict

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,9 +239,9 @@ class HtmlWebpackPlugin {
             return self.options.showErrors ? prettyError(err, compiler.context).toHtml() : 'ERROR';
           })
           .then(html => {
-            // Allow to use [contenthash] as placeholder for the html-webpack-plugin name
+            // Allow to use [hashByContent] as placeholder for the html-webpack-plugin name
             // From https://github.com/webpack-contrib/extract-text-webpack-plugin/blob/8de6558e33487e7606e7cd7cb2adc2cccafef272/src/index.js#L212-L214
-            const finalOutputName = self.childCompilationOutputName.replace(/\[(?:(\w+):)?contenthash(?::([a-z]+\d*))?(?::(\d+))?\]/ig, function () {
+            const finalOutputName = self.childCompilationOutputName.replace(/\[(?:(\w+):)?hashByContent(?::([a-z]+\d*))?(?::(\d+))?\]/ig, function () {
               return loaderUtils.getHashDigest(html, arguments[1], arguments[2], parseInt(arguments[3], 10));
             });
             // Replace the compilation result with the evaluated html code

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -630,7 +630,7 @@ describe('HtmlWebpackPlugin', () => {
     }, ['<script src="index_bundle.js"'], /test-\S+\.html$/, done);
   });
 
-  it('will replace [contenthash] in the filename with a content hash of 32 hex characters', done => {
+  it('will replace [hashByContent] in the filename with a content hash of 32 hex characters', done => {
     testHtmlPlugin({
       mode: 'production',
       entry: {
@@ -641,7 +641,7 @@ describe('HtmlWebpackPlugin', () => {
         filename: '[name]_bundle.js'
       },
       plugins: [
-        new HtmlWebpackPlugin({filename: 'index.[contenthash].html'})
+        new HtmlWebpackPlugin({filename: 'index.[hashByContent].html'})
       ]
     }, [], /index\.[a-f0-9]{32}\.html/, done);
   });


### PR DESCRIPTION
This occurs with webpack >= 4.3 because they internally added a [contentHash] variable. The simplest way around it is to rename the key to something else which is what I did here. I needed a quick fix for it, but I also stand by the choice of choosing a different key there because:

1. more declarative as to what it is doing
2. treating webpack internal variables as a black box

Closes #1033 