### PR TITLE
Update link address to loader order in Webpack docs

### DIFF
--- a/docs/template-option.md
+++ b/docs/template-option.md
@@ -36,7 +36,7 @@ Be aware, using `.html` as your template extention may unexpectedly trigger anot
 
 ```js
 new HtmlWebpackPlugin({
-  // For details on `!!` see https://webpack.github.io/docs/loaders.html#loader-order
+  // For details on `!!` see https://webpack.js.org/concepts/loaders/#loader-features
   template: '!!handlebars!src/index.hbs'
 })
 ```


### PR DESCRIPTION
Old link goes to old docs warning then redirects to main webpack page. Found the relevant content in the new webpack docs and replaced the link.