### PR TITLE
chore: No longer leave a comment when issues/PRs are locked

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -7,16 +7,8 @@ exemptLabels: []
 lockLabel: false
 
 # Comment to post before locking. Set to `false` to disable
-lockComment: >
-  This issue has been automatically locked since there has not been
-  any recent activity after it was closed. Please [open a new issue](https://github.com/jantimon/html-webpack-plugin/issues/new) for
-  related bugs.
+lockComment: false
 
 # Number of days of inactivity before a closed issue or pull request is locked
 daysUntilLock: 30
 
-pulls:
-  lockComment: >
-    This pull request has been automatically locked since there has not been
-    any recent activity after it was closed. Please [open a new issue](https://github.com/jantimon/html-webpack-plugin/issues/new) for
-    related bugs.


### PR DESCRIPTION
Since it creates too much email notification noise, and the reason for locking should be clear enough on its own (it's performed by a username of `lockbot` and the status of the issue/PR is set to `"resolved"`).

I decided against adding a label, since it will only end up adding noise to the labels list and issue/PR search results that adds little value other than as a workaround for inability to set a custom GitHub lock reason.

Fixes #1085.