### PR TITLE
feat: drop workaround for "Uncaught TypeError: __webpack_require__(….) is not a function" to be compatible with webpack 5

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -119,18 +119,6 @@ class HtmlWebpackChildCompiler {
     new LibraryTemplatePlugin('HTML_WEBPACK_PLUGIN_RESULT', 'var').apply(childCompiler);
     new LoaderTargetPlugin('node').apply(childCompiler);
 
-    // Fix for "Uncaught TypeError: __webpack_require__(...) is not a function"
-    // Hot module replacement requires that every child compiler has its own
-    // cache. @see https://github.com/ampedandwired/html-webpack-plugin/pull/179
-    childCompiler.hooks.compilation.tap('HtmlWebpackPlugin', compilation => {
-      if (compilation.cache) {
-        if (!compilation.cache[compilerName]) {
-          compilation.cache[compilerName] = {};
-        }
-        compilation.cache = compilation.cache[compilerName];
-      }
-    });
-
     // Add all templates
     this.templates.forEach((template, index) => {
       new SingleEntryPlugin(childCompiler.context, template, `HtmlWebpackPlugin_${index}`).apply(childCompiler);


### PR DESCRIPTION
See https://github.com/jantimon/html-webpack-plugin/issues/1089

@niieani could you please take a look if this would be the required change?