### PR TITLE
Fix TypeScript types

### DIFF
--- a/index.js
+++ b/index.js
@@ -630,7 +630,7 @@ class HtmlWebpackPlugin {
    *
    * @param {string|false} faviconFilePath
    * @param {WebpackCompilation} compilation
-   * @parma {string} publicPath
+   * @param {string} publicPath
    * @returns {Promise<string|undefined>}
    */
   getFaviconPublicPath (faviconFilePath, compilation, publicPath) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 // Import types
 /** @typedef {import("./typings").HtmlTagObject} HtmlTagObject */
 /** @typedef {import("./typings").Options} HtmlWebpackOptions */
-/** @typedef {import("./typings").InternalOptions} HtmlWebpackInternalOptions */
+/** @typedef {import("./typings").ProcessedOptions} ProcessedHtmlWebpackOptions */
 /** @typedef {import("./typings").TemplateParameter} TemplateParameter */
 /** @typedef {import("webpack/lib/Compiler.js")} WebpackCompiler */
 /** @typedef {import("webpack/lib/Compilation.js")} WebpackCompilation */
@@ -36,7 +36,7 @@ class HtmlWebpackPlugin {
     const userOptions = options || {};
 
     // Default options
-    /** @type {HtmlWebpackInternalOptions} */
+    /** @type {ProcessedHtmlWebpackOptions} */
     const defaultOptions = {
       template: path.join(__dirname, 'default_index.ejs'),
       templateContent: false,
@@ -57,7 +57,7 @@ class HtmlWebpackPlugin {
       xhtml: false
     };
 
-    /** @type {HtmlWebpackInternalOptions} */
+    /** @type {ProcessedHtmlWebpackOptions} */
     this.options = Object.assign(defaultOptions, userOptions);
 
     // Default metaOptions if no template is provided
@@ -922,7 +922,7 @@ class HtmlWebpackPlugin {
      headTags: HtmlTagObject[],
      bodyTags: HtmlTagObject[]
    }} assetTags
- * @param {HtmlWebpackInternalOptions} options
+ * @param {ProcessedHtmlWebpackOptions} options
  * @returns {TemplateParameter}
  */
 function templateParametersGenerator (compilation, assets, assetTags, options) {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 // @ts-check
 // Import types
-/* eslint-disable */
-/// <reference types="webpack" />
-/* eslint-enable */
+/** @typedef {import("./typings").HtmlTagObject} HtmlTagObject */
+/** @typedef {import("./typings").Options} HtmlWebpackOptions */
+/** @typedef {import("./typings").InternalOptions} HtmlWebpackInternalOptions */
+/** @typedef {import("./typings").TemplateParameter} TemplateParameter */
+/** @typedef {import("webpack/lib/Compiler.js")} WebpackCompiler */
+/** @typedef {import("webpack/lib/Compilation.js")} WebpackCompilation */
 'use strict';
 
 // use Polyfill for util.promisify in node versions < v8
@@ -26,14 +29,14 @@ const fsReadFileAsync = promisify(fs.readFile);
 
 class HtmlWebpackPlugin {
   /**
-   * @param {HtmlWebpackPlugin.Options} [options]
+   * @param {HtmlWebpackOptions} [options]
    */
   constructor (options) {
-    /** @type {HtmlWebpackPlugin.} */
+    /** @type {HtmlWebpackOptions} */
     const userOptions = options || {};
 
     // Default options
-    /** @type {HtmlWebpackPlugin.Options} */
+    /** @type {HtmlWebpackInternalOptions} */
     const defaultOptions = {
       template: path.join(__dirname, 'default_index.ejs'),
       templateContent: false,
@@ -54,7 +57,7 @@ class HtmlWebpackPlugin {
       xhtml: false
     };
 
-    /** @type {HtmlWebpackPlugin.Options} */
+    /** @type {HtmlWebpackInternalOptions} */
     this.options = Object.assign(defaultOptions, userOptions);
 
     // Default metaOptions if no template is provided
@@ -80,7 +83,7 @@ class HtmlWebpackPlugin {
 
   /**
    * apply is called by the webpack main compiler during the start phase
-   * @param {webpack.Compiler} compiler
+   * @param {WebpackCompiler} compiler
    */
   apply (compiler) {
     const self = this;
@@ -110,6 +113,7 @@ class HtmlWebpackPlugin {
 
     const minify = this.options.minify;
     if (minify === true || (minify === undefined && isProductionLikeMode)) {
+      /** @type { import('html-minifier').Options } */
       this.options.minify = {
         // https://github.com/kangax/html-minifier#options-quick-reference
         collapseWhitespace: true,
@@ -166,7 +170,7 @@ class HtmlWebpackPlugin {
     compiler.hooks.emit.tapAsync('HtmlWebpackPlugin',
       /**
        * Hook into the webpack emit phase
-       * @param {webpack.Compilation} compilation
+       * @param {WebpackCompilation} compilation
        * @param {() => void} callback
       */
       (compilation, callback) => {
@@ -315,7 +319,7 @@ class HtmlWebpackPlugin {
 
   /**
    * Evaluates the child compilation result
-   * @param {webpack.Compilation} compilation
+   * @param {WebpackCompilation} compilation
    * @param {string} source
    * @returns {Promise<string | (() => string | Promise<string>)>}
    */
@@ -346,7 +350,7 @@ class HtmlWebpackPlugin {
 
   /**
    * Generate the template parameters for the template function
-   * @param {webpack.Compilation} compilation
+   * @param {WebpackCompilation} compilation
    * @param {{
       publicPath: string,
       js: Array<string>,
@@ -379,7 +383,7 @@ class HtmlWebpackPlugin {
   /**
    * This function renders the actual html by executing the template function
    *
-   * @param {(templatePArameters) => string | Promise<string>} templateFunction
+   * @param {(templateParameters) => string | Promise<string>} templateFunction
    * @param {{
       publicPath: string,
       js: Array<string>,
@@ -391,7 +395,7 @@ class HtmlWebpackPlugin {
        headTags: HtmlTagObject[],
        bodyTags: HtmlTagObject[]
      }} assetTags
-   * @param {webpack.Compilation} compilation
+   * @param {WebpackCompilation} compilation
    *
    * @returns Promise<string>
    */
@@ -440,7 +444,7 @@ class HtmlWebpackPlugin {
   /*
    * Pushes the content of the given filename to the compilation assets
    * @param {string} filename
-   * @param {webpack.Compilation} compilation
+   * @param {WebpackCompilation} compilation
    *
    * @returns {string} file basename
    */
@@ -472,7 +476,7 @@ class HtmlWebpackPlugin {
    * Helper to sort chunks
    * @param {string[]} entryNames
    * @param {string|((entryNameA: string, entryNameB: string) => number)} sortMode
-   * @param {webpack.Compilation} compilation
+   * @param {WebpackCompilation} compilation
    */
   sortEntryChunks (entryNames, sortMode, compilation) {
     // Custom function
@@ -525,7 +529,7 @@ class HtmlWebpackPlugin {
   /**
    * The htmlWebpackPluginAssets extracts the asset information of a webpack compilation
    * for all given entry names
-   * @param {webpack.Compilation} compilation
+   * @param {WebpackCompilation} compilation
    * @param {string[]} entryNames
    * @returns {{
       publicPath: string,
@@ -625,7 +629,7 @@ class HtmlWebpackPlugin {
    * and returns the url to the ressource
    *
    * @param {string|false} faviconFilePath
-   * @param {webpack.Compilation} compilation
+   * @param {WebpackCompilation} compilation
    * @parma {string} publicPath
    * @returns {Promise<string|undefined>}
    */
@@ -875,7 +879,7 @@ class HtmlWebpackPlugin {
   /**
    * Helper to return the absolute template path with a fallback loader
    * @param {string} template
-   * The path to the tempalate e.g. './index.html'
+   * The path to the template e.g. './index.html'
    * @param {string} context
    * The webpack base resolution path for relative paths e.g. process.cwd()
    */
@@ -906,7 +910,7 @@ class HtmlWebpackPlugin {
  * Generate the template parameters
  *
  * Generate the template parameters for the template function
- * @param {webpack.Compilation} compilation
+ * @param {WebpackCompilation} compilation
  * @param {{
    publicPath: string,
    js: Array<string>,
@@ -918,8 +922,8 @@ class HtmlWebpackPlugin {
      headTags: HtmlTagObject[],
      bodyTags: HtmlTagObject[]
    }} assetTags
- * @param {HtmlWebpackPlugin.Options} options
- * @returns {HtmlWebpackPlugin.TemplateParameter}
+ * @param {HtmlWebpackInternalOptions} options
+ * @returns {TemplateParameter}
  */
 function templateParametersGenerator (compilation, assets, assetTags, options) {
   const xhtml = options.xhtml;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 // @ts-check
 // Import types
 /* eslint-disable */
-/// <reference path="./typings.d.ts" />
+/// <reference types="webpack" />
 /* eslint-enable */
-/** @typedef {import("webpack/lib/Compiler.js")} WebpackCompiler */
-/** @typedef {import("webpack/lib/Compilation.js")} WebpackCompilation */
 'use strict';
 
 // use Polyfill for util.promisify in node versions < v8
@@ -28,14 +26,14 @@ const fsReadFileAsync = promisify(fs.readFile);
 
 class HtmlWebpackPlugin {
   /**
-   * @param {Partial<HtmlWebpackPluginOptions>} [options]
+   * @param {HtmlWebpackPlugin.Options} [options]
    */
   constructor (options) {
-    /** @type {Partial<HtmlWebpackPluginOptions>} */
+    /** @type {HtmlWebpackPlugin.} */
     const userOptions = options || {};
 
     // Default options
-    /** @type {HtmlWebpackPluginOptions} */
+    /** @type {HtmlWebpackPlugin.Options} */
     const defaultOptions = {
       template: path.join(__dirname, 'default_index.ejs'),
       templateContent: false,
@@ -56,7 +54,7 @@ class HtmlWebpackPlugin {
       xhtml: false
     };
 
-    /** @type {HtmlWebpackPluginOptions} */
+    /** @type {HtmlWebpackPlugin.Options} */
     this.options = Object.assign(defaultOptions, userOptions);
 
     // Default metaOptions if no template is provided
@@ -82,7 +80,7 @@ class HtmlWebpackPlugin {
 
   /**
    * apply is called by the webpack main compiler during the start phase
-   * @param {WebpackCompiler} compiler
+   * @param {webpack.Compiler} compiler
    */
   apply (compiler) {
     const self = this;
@@ -168,7 +166,7 @@ class HtmlWebpackPlugin {
     compiler.hooks.emit.tapAsync('HtmlWebpackPlugin',
       /**
        * Hook into the webpack emit phase
-       * @param {WebpackCompilation} compilation
+       * @param {webpack.Compilation} compilation
        * @param {() => void} callback
       */
       (compilation, callback) => {
@@ -317,7 +315,7 @@ class HtmlWebpackPlugin {
 
   /**
    * Evaluates the child compilation result
-   * @param {WebpackCompilation} compilation
+   * @param {webpack.Compilation} compilation
    * @param {string} source
    * @returns {Promise<string | (() => string | Promise<string>)>}
    */
@@ -348,7 +346,7 @@ class HtmlWebpackPlugin {
 
   /**
    * Generate the template parameters for the template function
-   * @param {WebpackCompilation} compilation
+   * @param {webpack.Compilation} compilation
    * @param {{
       publicPath: string,
       js: Array<string>,
@@ -393,7 +391,7 @@ class HtmlWebpackPlugin {
        headTags: HtmlTagObject[],
        bodyTags: HtmlTagObject[]
      }} assetTags
-   * @param {WebpackCompilation} compilation
+   * @param {webpack.Compilation} compilation
    *
    * @returns Promise<string>
    */
@@ -442,7 +440,7 @@ class HtmlWebpackPlugin {
   /*
    * Pushes the content of the given filename to the compilation assets
    * @param {string} filename
-   * @param {WebpackCompilation} compilation
+   * @param {webpack.Compilation} compilation
    *
    * @returns {string} file basename
    */
@@ -474,7 +472,7 @@ class HtmlWebpackPlugin {
    * Helper to sort chunks
    * @param {string[]} entryNames
    * @param {string|((entryNameA: string, entryNameB: string) => number)} sortMode
-   * @param {WebpackCompilation} compilation
+   * @param {webpack.Compilation} compilation
    */
   sortEntryChunks (entryNames, sortMode, compilation) {
     // Custom function
@@ -527,7 +525,7 @@ class HtmlWebpackPlugin {
   /**
    * The htmlWebpackPluginAssets extracts the asset information of a webpack compilation
    * for all given entry names
-   * @param {WebpackCompilation} compilation
+   * @param {webpack.Compilation} compilation
    * @param {string[]} entryNames
    * @returns {{
       publicPath: string,
@@ -627,7 +625,7 @@ class HtmlWebpackPlugin {
    * and returns the url to the ressource
    *
    * @param {string|false} faviconFilePath
-   * @param {WebpackCompilation} compilation
+   * @param {webpack.Compilation} compilation
    * @parma {string} publicPath
    * @returns {Promise<string|undefined>}
    */
@@ -908,7 +906,7 @@ class HtmlWebpackPlugin {
  * Generate the template parameters
  *
  * Generate the template parameters for the template function
- * @param {WebpackCompilation} compilation
+ * @param {webpack.Compilation} compilation
  * @param {{
    publicPath: string,
    js: Array<string>,
@@ -920,8 +918,8 @@ class HtmlWebpackPlugin {
      headTags: HtmlTagObject[],
      bodyTags: HtmlTagObject[]
    }} assetTags
- * @param {HtmlWebpackPluginOptions} options
- * @returns {HtmlWebpackPluginTemplateParameter}
+ * @param {HtmlWebpackPlugin.Options} options
+ * @returns {HtmlWebpackPlugin.TemplateParameter}
  */
 function templateParametersGenerator (compilation, assets, assetTags, options) {
   const xhtml = options.xhtml;

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -10,6 +10,59 @@
 
 const AsyncSeriesWaterfallHook = require('tapable').AsyncSeriesWaterfallHook;
 
+// The following is the API definition for all available hooks
+// For the TypeScript definition, see the Hooks type in typings.d.ts
+/**
+  beforeAssetTagGeneration:
+    AsyncSeriesWaterfallHook<{
+      assets: {
+        publicPath: string,
+        js: Array<string>,
+        css: Array<string>,
+        favicon?: string | undefined,
+        manifest?: string | undefined
+      },
+      outputName: string,
+      plugin: HtmlWebpackPlugin
+    }>,
+  alterAssetTags:
+    AsyncSeriesWaterfallHook<{
+      assetTags: {
+        scripts: Array<HtmlTagObject>,
+        styles: Array<HtmlTagObject>,
+        meta: Array<HtmlTagObject>,
+      },
+      outputName: string,
+      plugin: HtmlWebpackPlugin
+    }>,
+  alterAssetTagGroups:
+    AsyncSeriesWaterfallHook<{
+      headTags: Array<HtmlTagObject | HtmlTagObject>,
+      bodyTags: Array<HtmlTagObject | HtmlTagObject>,
+      outputName: string,
+      plugin: HtmlWebpackPlugin
+    }>,
+  afterTemplateExecution:
+    AsyncSeriesWaterfallHook<{
+      html: string,
+      headTags: Array<HtmlTagObject | HtmlTagObject>,
+      bodyTags: Array<HtmlTagObject | HtmlTagObject>,
+      outputName: string,
+      plugin: HtmlWebpackPlugin,
+    }>,
+  beforeEmit:
+    AsyncSeriesWaterfallHook<{
+      html: string,
+      outputName: string,
+      plugin: HtmlWebpackPlugin,
+    }>,
+  afterEmit:
+    AsyncSeriesWaterfallHook<{
+      outputName: string,
+      plugin: HtmlWebpackPlugin
+    }>
+*/
+
 /**
  * @type {WeakMap<WebpackCompilation, HtmlWebpackPluginHooks>}}
  */

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,7 +1,5 @@
 // @ts-check
-/* eslint-disable */
-/// <reference path="../typings.d.ts" />
-/* eslint-enable */
+/** @typedef {import("../typings").Hooks} HtmlWebpackPluginHooks */
 'use strict';
 /**
  * This file provides access to all public htmlWebpackPlugin hooks
@@ -11,67 +9,6 @@
 /** @typedef {import("../index.js")} HtmlWebpackPlugin */
 
 const AsyncSeriesWaterfallHook = require('tapable').AsyncSeriesWaterfallHook;
-
-// The following typedef holds the API definition for all available hooks
-// to allow easier access when using ts-check or typescript inside plugins
-/** @typedef {{
-
-  beforeAssetTagGeneration:
-    AsyncSeriesWaterfallHook<{
-      assets: {
-        publicPath: string,
-        js: Array<string>,
-        css: Array<string>,
-        favicon?: string | undefined,
-        manifest?: string | undefined
-      },
-      outputName: string,
-      plugin: HtmlWebpackPlugin
-    }>,
-
-  alterAssetTags:
-    AsyncSeriesWaterfallHook<{
-      assetTags: {
-        scripts: Array<HtmlTagObject>,
-        styles: Array<HtmlTagObject>,
-        meta: Array<HtmlTagObject>,
-      },
-      outputName: string,
-      plugin: HtmlWebpackPlugin
-    }>,
-
-  alterAssetTagGroups:
-    AsyncSeriesWaterfallHook<{
-      headTags: Array<HtmlTagObject | HtmlTagObject>,
-      bodyTags: Array<HtmlTagObject | HtmlTagObject>,
-      outputName: string,
-      plugin: HtmlWebpackPlugin
-    }>,
-
-  afterTemplateExecution:
-    AsyncSeriesWaterfallHook<{
-      html: string,
-      headTags: Array<HtmlTagObject | HtmlTagObject>,
-      bodyTags: Array<HtmlTagObject | HtmlTagObject>,
-      outputName: string,
-      plugin: HtmlWebpackPlugin,
-    }>,
-
-  beforeEmit:
-    AsyncSeriesWaterfallHook<{
-      html: string,
-      outputName: string,
-      plugin: HtmlWebpackPlugin,
-    }>,
-
-  afterEmit:
-    AsyncSeriesWaterfallHook<{
-      outputName: string,
-      plugin: HtmlWebpackPlugin
-    }>,
-
-  }} HtmlWebpackPluginHooks
-  */
 
 /**
  * @type {WeakMap<WebpackCompilation, HtmlWebpackPluginHooks>}}

--- a/lib/html-tags.js
+++ b/lib/html-tags.js
@@ -1,7 +1,5 @@
 // @ts-check
-/* eslint-disable */
-/// <reference path="../typings.d.ts" />
-/* eslint-enable */
+/** @typedef {import("../typings").HtmlTagObject} HtmlTagObject */
 /**
  * @file
  * This file provides to helper to create html as a object repesentation as

--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
     ]
   },
   "devDependencies": {
+    "@types/html-minifier": "^3.5.2",
     "@types/loader-utils": "1.1.3",
     "@types/node": "10.11.4",
     "@types/tapable": "1.0.4",
+    "@types/webpack": "^4.0.0",
     "appcache-webpack-plugin": "^1.4.0",
     "commitizen": "3.0.2",
     "css-loader": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Simplifies creation of HTML files to serve your webpack bundles",
   "author": "Jan Nicklas <j.nicklas@me.com> (https://github.com/jantimon)",
   "main": "index.js",
+  "types": "typings.d.ts",
   "files": [
     "lib/",
     "index.js",

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -146,7 +146,7 @@ declare namespace HtmlWebpackPlugin {
    *
    *  The Required and Omit types are defined at the top of the file
    */
-  interface InternalOptions extends Required<Omit<Options, "minify">> {
+  interface ProcessedOptions extends Required<Omit<Options, "minify">> {
     minify: MinifyOptions | undefined;
   }
 

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -138,8 +138,13 @@ declare namespace HtmlWebpackPlugin {
   }
 
   /**
-   * The internally used options. This is a variant of the Options interface but with the types
-   * set up to match the expectations in index.js
+   * Options interface that matches the expectations of the index.js API:
+   *   - All fields are required
+   *   - The minify property matches what html-minifier expects (eg either a MinifyOptions or undefined).
+   *     html-minifier does not accept a boolean value. As TypeScript does not allow a property to be redefined
+   *     in an extended interface we need to omit it and then define it properly
+   *
+   *  The Required and Omit types are defined at the top of the file
    */
   interface InternalOptions extends Required<Omit<Options, "minify">> {
     minify: MinifyOptions | undefined;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,5 +1,13 @@
 import { Plugin } from "webpack";
+import { AsyncSeriesWaterfallHook } from "tapable";
 import { Options as HtmlMinifierOptions } from "html-minifier";
+
+// https://github.com/Microsoft/TypeScript/issues/15012#issuecomment-365453623
+type Required<T> = T extends object
+  ? { [P in keyof T]-?: NonNullable<T[P]> }
+  : T;
+// https://stackoverflow.com/questions/48215950/exclude-property-from-type
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export = HtmlWebpackPlugin;
 
@@ -15,9 +23,69 @@ declare namespace HtmlWebpackPlugin {
    */
   interface Options {
     /**
-     * The title to use for the generated HTML document
+     * Emit the file only if it was changed.
+     * Default: `true`.
      */
-    title?: string;
+    cache?: boolean;
+    /**
+     * List all entries which should be injected
+     */
+    chunks?: "all" | string[];
+    /**
+     * Allows to control how chunks should be sorted before they are included to the html.
+     * Default: `'auto'`.
+     */
+    chunksSortMode?:
+      | "auto"
+      | "manual"
+      | (((entryNameA: string, entryNameB: string) => number));
+    /**
+     * List all entries which should not be injeccted
+     */
+    excludeChunks?: string[];
+    /**
+     * Path to the favicon icon
+     */
+    favicon?: false | string;
+    /**
+     * The file to write the HTML to.
+     * Defaults to `index.html`.
+     * Supports subdirectories eg: `assets/admin.html`
+     */
+    filename?: string;
+    /**
+     * If `true` then append a unique `webpack` compilation hash to all included scripts and CSS files.
+     * This is useful for cache busting
+     */
+    hash?: boolean;
+    /**
+     * Inject all assets into the given `template` or `templateContent`.
+     */
+    inject?:
+      | false // Don't inject scripts
+      | true // Inject scripts into body
+      | "body" // Inject scripts into body
+      | "head"; // Inject scripts into head
+    /**
+     * Inject meta tags
+     */
+    meta?:
+      | false // Disable injection
+      | {
+          [name: string]:
+            | string
+            | false // name content pair e.g. {viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no'}`
+            | { [attributeName: string]: string | boolean }; // custom properties e.g. { name:"viewport" content:"width=500, initial-scale=1" }
+        };
+    /**
+     * HTML Minification options
+     * @https://github.com/kangax/html-minifier#options-quick-reference
+     */
+    minify?: boolean | MinifyOptions;
+    /**
+     * Render errors into the HTML page
+     */
+    showErrors?: boolean;
     /**
      * The `webpack` require path to the template.
      * @see https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md
@@ -39,8 +107,8 @@ declare namespace HtmlWebpackPlugin {
           compilation: any,
           assets,
           assetTags: {
-            headTags: Array<HtmlTagObject>;
-            bodyTags: Array<HtmlTagObject>;
+            headTags: HtmlTagObject[];
+            bodyTags: HtmlTagObject[];
           },
           options: Options
         ) => { [option: string]: any })
@@ -48,77 +116,20 @@ declare namespace HtmlWebpackPlugin {
           compilation: any,
           assets,
           assetTags: {
-            headTags: Array<HtmlTagObject>;
-            bodyTags: Array<HtmlTagObject>;
+            headTags: HtmlTagObject[];
+            bodyTags: HtmlTagObject[];
           },
           options: Options
         ) => Promise<{ [option: string]: any }>)
       | { [option: string]: any };
     /**
-     * The file to write the HTML to.
-     * Defaults to `index.html`.
-     * Supports subdirectories eg: `assets/admin.html`
+     * The title to use for the generated HTML document
      */
-    filename?: string;
-    /**
-     * If `true` then append a unique `webpack` compilation hash to all included scripts and CSS files.
-     * This is useful for cache busting
-     */
-    hash?: boolean;
-    /**
-     * Inject all assets into the given `template` or `templateContent`.
-     */
-    inject?:
-      | false // Don't inject scripts
-      | true // Inject scripts into body
-      | "body" // Inject scripts into body
-      | "head"; // Inject scripts into head
-    /**
-     * Path to the favicon icon
-     */
-    favicon?: false | string;
-    /**
-     * HTML Minification options
-     * @https://github.com/kangax/html-minifier#options-quick-reference
-     */
-    minify?: boolean | MinifyOptions;
-    /**
-     * Emit the file only if it was changed.
-     * Default: `true`.
-     */
-    cache?: boolean;
-    /**
-     * Render errors into the HTML page
-     */
-    showErrors?: boolean;
-    /**
-     * List all entries which should be injected
-     */
-    chunks?: "all" | string[];
-    /**
-     * List all entries which should not be injeccted
-     */
-    excludeChunks?: string[];
-    chunksSortMode?:
-      | "auto"
-      | "manual"
-      | (((entryNameA: string, entryNameB: string) => number));
-    /**
-     * Inject meta tags
-     */
-    meta?:
-      | false // Disable injection
-      | {
-          [name: string]:
-            | string
-            | false // name content pair e.g. {viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no'}`
-            | { [attributeName: string]: string | boolean }; // custom properties e.g. { name:"viewport" content:"width=500, initial-scale=1" }
-        };
+    title?: string;
     /**
      * Enforce self closing tags e.g. <link />
      */
     xhtml?: boolean;
-
     /**
      * In addition to the options actually used by this plugin, you can use this hash to pass arbitrary data through
      * to your template.
@@ -127,13 +138,20 @@ declare namespace HtmlWebpackPlugin {
   }
 
   /**
+   * The internally used options. This is a variant of the Options interface but with the types
+   * set up to match the expectations in index.js
+   */
+  interface InternalOptions extends Required<Omit<Options, "minify">> {
+    minify: MinifyOptions | undefined;
+  }
+
+  /**
    * The values which are available during template execution
    *
    * Please keep in mind that the `templateParameter` options allows to change them
    */
-  export interface TemplateParameter {
+  interface TemplateParameter {
     compilation: any;
-    webpackConfig: any;
     htmlWebpackPlugin: {
       tags: {
         headTags: HtmlTagObject[];
@@ -148,31 +166,82 @@ declare namespace HtmlWebpackPlugin {
       };
       options: Options;
     };
+    webpackConfig: any;
   }
-}
 
-/**
- * A tag element according to the htmlWebpackPlugin object notation
- */
-interface HtmlTagObject {
+  interface Hooks {
+    alterAssetTags: AsyncSeriesWaterfallHook<{
+      assetTags: {
+        scripts: HtmlTagObject[];
+        styles: HtmlTagObject[];
+        meta: HtmlTagObject[];
+      };
+      outputName: string;
+      plugin: HtmlWebpackPlugin;
+    }>;
+
+    alterAssetTagGroups: AsyncSeriesWaterfallHook<{
+      headTags: HtmlTagObject[];
+      bodyTags: HtmlTagObject[];
+      outputName: string;
+      plugin: HtmlWebpackPlugin;
+    }>;
+
+    afterTemplateExecution: AsyncSeriesWaterfallHook<{
+      html: string;
+      headTags: HtmlTagObject[];
+      bodyTags: HtmlTagObject[];
+      outputName: string;
+      plugin: HtmlWebpackPlugin;
+    }>;
+
+    beforeAssetTagGeneration: AsyncSeriesWaterfallHook<{
+      assets: {
+        publicPath: string;
+        js: Array<string>;
+        css: Array<string>;
+        favicon?: string | undefined;
+        manifest?: string | undefined;
+      };
+      outputName: string;
+      plugin: HtmlWebpackPlugin;
+    }>;
+
+    beforeEmit: AsyncSeriesWaterfallHook<{
+      html: string;
+      outputName: string;
+      plugin: HtmlWebpackPlugin;
+    }>;
+
+    afterEmit: AsyncSeriesWaterfallHook<{
+      outputName: string;
+      plugin: HtmlWebpackPlugin;
+    }>;
+  }
+
   /**
-   * Attributes of the html tag
-   * E.g. `{'disabled': true, 'value': 'demo'}`
+   * A tag element according to the htmlWebpackPlugin object notation
    */
-  attributes: {
-    [attributeName: string]: string | boolean;
-  };
-  /**
-   * Wether this html must not contain innerHTML
-   * @see https://www.w3.org/TR/html5/syntax.html#void-elements
-   */
-  voidTag: boolean;
-  /**
-   * The tag name e.g. `'div'`
-   */
-  tagName: string;
-  /**
-   * Inner HTML The
-   */
-  innerHTML?: string;
+  interface HtmlTagObject {
+    /**
+     * Attributes of the html tag
+     * E.g. `{'disabled': true, 'value': 'demo'}`
+     */
+    attributes: {
+      [attributeName: string]: string | boolean;
+    };
+    /**
+     * The tag name e.g. `'div'`
+     */
+    tagName: string;
+    /**
+     * The inner HTML
+     */
+    innerHTML?: string;
+        /**
+     * Whether this html must not contain innerHTML
+     * @see https://www.w3.org/TR/html5/syntax.html#void-elements
+     */
+    voidTag: boolean;
+  }
 }

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,91 +1,154 @@
+import { Plugin } from "webpack";
+import { Options as HtmlMinifierOptions } from "html-minifier";
 
-/**
- * The plugin options
- */
-interface HtmlWebpackPluginOptions {
+export = HtmlWebpackPlugin;
+
+declare class HtmlWebpackPlugin extends Plugin {
+  constructor(options?: HtmlWebpackPlugin.Options);
+}
+
+declare namespace HtmlWebpackPlugin {
+  type MinifyOptions = HtmlMinifierOptions;
+
+  /**
+   * The plugin options
+   */
+  interface Options {
     /**
      * The title to use for the generated HTML document
      */
-    title: string,
+    title?: string;
     /**
      * The `webpack` require path to the template.
      * @see https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md
      */
-    template: string,
+    template?: string;
     /**
      * Allow to use a html string instead of reading from a file
      */
-    templateContent:
-      false // Use the template option instead to load a file
+    templateContent?:
+      | false // Use the template option instead to load a file
       | string
-      | Promise<string>,
+      | Promise<string>;
     /**
      * Allows to overwrite the parameters used in the template
      */
-    templateParameters:
-      false // Pass an empty object to the template function
-      | ((compilation: any, assets, assetTags: { headTags: Array<HtmlTagObject>, bodyTags: Array<HtmlTagObject> }, options: HtmlWebpackPluginOptions) => {[option: string]: any})
-      | ((compilation: any, assets, assetTags: { headTags: Array<HtmlTagObject>, bodyTags: Array<HtmlTagObject> }, options: HtmlWebpackPluginOptions) => Promise<{[option: string]: any}>)
-      | {[option: string]: any}
+    templateParameters?:
+      | false // Pass an empty object to the template function
+      | ((
+          compilation: any,
+          assets,
+          assetTags: {
+            headTags: Array<HtmlTagObject>;
+            bodyTags: Array<HtmlTagObject>;
+          },
+          options: Options
+        ) => { [option: string]: any })
+      | ((
+          compilation: any,
+          assets,
+          assetTags: {
+            headTags: Array<HtmlTagObject>;
+            bodyTags: Array<HtmlTagObject>;
+          },
+          options: Options
+        ) => Promise<{ [option: string]: any }>)
+      | { [option: string]: any };
     /**
      * The file to write the HTML to.
      * Defaults to `index.html`.
      * Supports subdirectories eg: `assets/admin.html`
      */
-    filename: string,
+    filename?: string;
     /**
      * If `true` then append a unique `webpack` compilation hash to all included scripts and CSS files.
      * This is useful for cache busting
      */
-    hash: boolean,
+    hash?: boolean;
     /**
      * Inject all assets into the given `template` or `templateContent`.
      */
-    inject: false // Don't inject scripts
-    | true    // Inject scripts into body
-    | 'body'  // Inject scripts into body
-    | 'head'  // Inject scripts into head
+    inject?:
+      | false // Don't inject scripts
+      | true // Inject scripts into body
+      | "body" // Inject scripts into body
+      | "head"; // Inject scripts into head
     /**
      * Path to the favicon icon
      */
-    favicon: false | string,
+    favicon?: false | string;
     /**
      * HTML Minification options
      * @https://github.com/kangax/html-minifier#options-quick-reference
      */
-    minify?: boolean | {},
-    cache: boolean,
+    minify?: boolean | MinifyOptions;
+    /**
+     * Emit the file only if it was changed.
+     * Default: `true`.
+     */
+    cache?: boolean;
     /**
      * Render errors into the HTML page
      */
-    showErrors: boolean,
+    showErrors?: boolean;
     /**
      * List all entries which should be injected
      */
-    chunks: 'all' | string[],
+    chunks?: "all" | string[];
     /**
      * List all entries which should not be injeccted
      */
-    excludeChunks: string[],
-    chunksSortMode: 'auto' | 'manual' | (((entryNameA: string, entryNameB: string) => number)),
+    excludeChunks?: string[];
+    chunksSortMode?:
+      | "auto"
+      | "manual"
+      | (((entryNameA: string, entryNameB: string) => number));
     /**
      * Inject meta tags
      */
-    meta: false // Disable injection
+    meta?:
+      | false // Disable injection
       | {
-          [name: string]: string|false // name content pair e.g. {viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no'}`
-          | {[attributeName: string]: string|boolean} // custom properties e.g. { name:"viewport" content:"width=500, initial-scale=1" }
-      },
+          [name: string]:
+            | string
+            | false // name content pair e.g. {viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no'}`
+            | { [attributeName: string]: string | boolean }; // custom properties e.g. { name:"viewport" content:"width=500, initial-scale=1" }
+        };
     /**
      * Enforce self closing tags e.g. <link />
      */
-    xhtml: boolean
+    xhtml?: boolean;
 
     /**
      * In addition to the options actually used by this plugin, you can use this hash to pass arbitrary data through
      * to your template.
      */
     [option: string]: any;
+  }
+
+  /**
+   * The values which are available during template execution
+   *
+   * Please keep in mind that the `templateParameter` options allows to change them
+   */
+  export interface TemplateParameter {
+    compilation: any;
+    webpackConfig: any;
+    htmlWebpackPlugin: {
+      tags: {
+        headTags: HtmlTagObject[];
+        bodyTags: HtmlTagObject[];
+      };
+      files: {
+        publicPath: string;
+        js: Array<string>;
+        css: Array<string>;
+        manifest?: string;
+        favicon?: string;
+      };
+      options: Options;
+    };
+  }
 }
 
 /**
@@ -97,43 +160,19 @@ interface HtmlTagObject {
    * E.g. `{'disabled': true, 'value': 'demo'}`
    */
   attributes: {
-    [attributeName: string]: string|boolean
-  },
+    [attributeName: string]: string | boolean;
+  };
   /**
    * Wether this html must not contain innerHTML
    * @see https://www.w3.org/TR/html5/syntax.html#void-elements
    */
-  voidTag: boolean,
+  voidTag: boolean;
   /**
    * The tag name e.g. `'div'`
    */
-  tagName: string,
+  tagName: string;
   /**
    * Inner HTML The
    */
-  innerHTML?: string
-}
-
-/**
- * The values which are available during template execution
- *
- * Please keep in mind that the `templateParameter` options allows to change them
- */
-interface HtmlWebpackPluginTemplateParameter {
-  compilation: any,
-  webpackConfig: any
-  htmlWebpackPlugin: {
-    tags: {
-      headTags: HtmlTagObject[],
-      bodyTags: HtmlTagObject[]
-    },
-    files: {
-      publicPath: string,
-      js: Array<string>,
-      css: Array<string>,
-      manifest?: string,
-      favicon?: string
-    },
-    options: HtmlWebpackPluginOptions
-  }
+  innerHTML?: string;
 }


### PR DESCRIPTION
This resolves #1108

* Adds `types` property to `package.json` (see [Publishing docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html))
* Revamps the `typings.d.ts` file to more accurately reflect both the internal and external API. Specifically, the `Options` interface should have every property marked optional (for external consumption) but most of those properties are assumed to be not null/undefined throughout `index.js`. I thus introduced an `InternalOptions` interface which matches this requirement.
* Moved the `Hooks` typedef into the `typings.d.ts` file vs defining it inline.
* Moved `HtmlTagObject` inside the `HtmlWebpackPlugin` namespace.

I did not fix compatibility with `noImplicitAny` in this PR. As you are shipping an annotated JS file, I believe TS users downstream with both `noImplicitAny` and `allowJs` enabled will get a bunch of compiler warnings.

cc @SimonSchick