### PR TITLE
fix: Use src/index.ejs by default if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Allowed values are as follows
 |:--:|:--:|:-----:|:----------|
 |**`title`**|`{String}`|`Webpack App`|The title to use for the generated HTML document|
 |**`filename`**|`{String}`|`'index.html'`|The file to write the HTML to. Defaults to `index.html`. You can specify a subdirectory here too (eg: `assets/admin.html`)|
-|**`template`**|`{String}`|``|`webpack` require path to the template. Please see the [docs](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md) for details|
-|**[`templateParameters`](#)**|`{Boolean\|Object\|Function}`|``| Allows to overwrite the parameters used in the template |
+|**`template`**|`{String}`|``|`webpack` relative or absolute path to the template. By default it will use `src/index.ejs` if it exists. Please see the [docs](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md) for details|
+|**`templateParameters`**|`{Boolean\|Object\|Function}`|``| Allows to overwrite the parameters used in the template |
 |**`inject`**|`{Boolean\|String}`|`true`|`true \|\| 'head' \|\| 'body' \|\| false` Inject all assets into the given `template` or `templateContent`. When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element|
 |**`favicon`**|`{String}`|``|Adds the given favicon path to the output HTML|
 |**`meta`**|`{Object}`|`{}`|Allows to inject `meta`-tags. E.g. `meta: {viewport: 'width=device-width, initial-scale=1, shrink-to-fit=no'}`|

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ class HtmlWebpackPlugin {
     // Default options
     /** @type {ProcessedHtmlWebpackOptions} */
     const defaultOptions = {
-      template: path.join(__dirname, 'default_index.ejs'),
+      template: 'auto',
       templateContent: false,
       templateParameters: templateParametersGenerator,
       filename: 'index.html',
@@ -908,6 +908,12 @@ class HtmlWebpackPlugin {
    * The webpack base resolution path for relative paths e.g. process.cwd()
    */
   getFullTemplatePath (template, context) {
+    if (template === 'auto') {
+      template = path.resolve(context, 'src/index.ejs');
+      if (!fs.existsSync(template)) {
+        template = path.join(__dirname, 'default_index.ejs');
+      }
+    }
     // If the template doesn't use a loader use the lodash template loader
     if (template.indexOf('!') === -1) {
       template = require.resolve('./lib/loader.js') + '!' + path.resolve(context, template);

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -214,6 +214,22 @@ describe('HtmlWebpackPlugin', () => {
     ['<script src="app_bundle.js', 'Some unique text'], null, done);
   });
 
+  it('picks up src/index.ejs by default', done => {
+    testHtmlPlugin({
+      mode: 'production',
+      context: path.join(__dirname, 'fixtures'),
+      entry: {
+        app: './index.js'
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin()]
+    },
+    ['<script src="app_bundle.js', 'src/index.ejs'], null, done);
+  });
+
   it('allows you to inject the assets into a given html file', done => {
     testHtmlPlugin({
       mode: 'production',

--- a/spec/fixtures/src/index.ejs
+++ b/spec/fixtures/src/index.ejs
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>src/index.ejs</title>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
BREAKING CHANGE: Use `src/index.ejs` if no template option is set.

Webpack will pick up `src/` by default that means depending on your resolving settings it will use `src/index.js`, `src/index.jsx`, `src/index.ts` ... or similar by default.

This pull request adds the same feature for the html-webpack-plugin.

I would love to know what you think in general about this pull request and if we should support:

`src/index.ejs`
`src/index.html`
or
`public/index.html`


cc @sokra @edmorley 