### PR TITLE
feat: allow for templates resolved from modules

### DIFF
--- a/__mocks__/fake-module/plain.html
+++ b/__mocks__/fake-module/plain.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en" manifest="foo.appcache">
+<head>
+  <meta charset="utf-8">
+  <title>Example Plain file</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+</body>
+</html>

--- a/__mocks__/fake-module/test.html
+++ b/__mocks__/fake-module/test.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Test</title>
+  </head>
+  <body>
+    <p>Some unique text</p>
+    <script src="<%=htmlWebpackPlugin.files.js[0]%>"></script>
+  </body>
+</html>

--- a/index.js
+++ b/index.js
@@ -914,14 +914,27 @@ class HtmlWebpackPlugin {
         template = path.join(__dirname, 'default_index.ejs');
       }
     }
+
+    const getTemplatePath = (filepath, pathContext = '') => {
+      let resolvedPath = '';
+      try {
+        resolvedPath = require.resolve(filepath);
+      } catch (e) {
+      } finally {
+        resolvedPath = resolvedPath || path.resolve(pathContext, filepath);
+      }
+
+      return resolvedPath;
+    };
+
     // If the template doesn't use a loader use the lodash template loader
     if (template.indexOf('!') === -1) {
-      template = require.resolve('./lib/loader.js') + '!' + path.resolve(context, template);
+      template = require.resolve('./lib/loader.js') + '!' + getTemplatePath(template, context);
     }
     // Resolve template path
     return template.replace(
       /([!])([^/\\][^!?]+|[^/\\!?])($|\?[^!?\n]+$)/,
-      (match, prefix, filepath, postfix) => prefix + path.resolve(filepath) + postfix);
+      (match, prefix, filepath, postfix) => prefix + getTemplatePath(filepath) + postfix);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     }
   },
   "jest": {
+    "moduleDirectories": ["node_modules", "__mocks__"],
     "watchPathIgnorePatterns": [
       "<rootDir>/dist"
     ],

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -214,6 +214,42 @@ describe('HtmlWebpackPlugin', () => {
     ['<script src="app_bundle.js', 'Some unique text'], null, done);
   });
 
+  it('allows you to specify a template file from a module', done => {
+    testHtmlPlugin({
+      mode: 'production',
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        inject: true,
+        template: 'html-loader!fake-module/test.html'
+      })]
+    },
+    ['<script src="app_bundle.js', 'Some unique text'], null, done);
+  });
+
+  it('allows you to specify a template file from a module using a loader', done => {
+    testHtmlPlugin({
+      mode: 'production',
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        inject: true,
+        template: 'html-loader!fake-module/test.html'
+      })]
+    },
+    ['<script src="app_bundle.js"', 'Some unique text'], null, done);
+  });
+
   it('picks up src/index.ejs by default', done => {
     testHtmlPlugin({
       mode: 'production',

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -244,10 +244,10 @@ describe('HtmlWebpackPlugin', () => {
       },
       plugins: [new HtmlWebpackPlugin({
         inject: true,
-        template: 'html-loader!fake-module/test.html'
+        template: 'html-loader!fake-module/plain.html'
       })]
     },
-    ['<script src="app_bundle.js"', 'Some unique text'], null, done);
+    ['<script src="app_bundle.js"'], null, done);
   });
 
   it('picks up src/index.ejs by default', done => {


### PR DESCRIPTION
In cases where a module might export a template file, this allows for importing from those modules directly.

This could also be accomplished at the downstream level with something like:
```es6
// ...
new HtmlWebpackPlugin({
  template: require.resolve('my-module/template.html'),
  // ...
})
```

With the new template loading functionality in the PR, that simply looks like:
```es6
// ...
new HtmlWebpackPlugin({
  template: 'my-module/template.html',
  // ...
})
```