### PR TITLE
Restore chunk info to template parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,11 +263,11 @@ The following variables are available in the template:
         "js": [ "assets/head_bundle.js", "assets/main_bundle.js"],
         "chunks": {
           "head": {
-            "entry": "assets/head_bundle.js",
+            "js": ["assets/head_bundle.js"],
             "css": [ "main.css" ]
           },
           "main": {
-            "entry": "assets/main_bundle.js",
+            "js": ["assets/main_bundle.js"],
             "css": []
           },
         }

--- a/index.js
+++ b/index.js
@@ -612,8 +612,13 @@ class HtmlWebpackPlugin {
 
     const stats = compilation.getStats().toJson({all: false, chunkGroups: true});
 
-    Object.entries(stats.namedChunkGroups).forEach(([chunkGroupName, chunkGroupStats]) => {
-      assets.chunks[chunkGroupName] = this.processFiles(chunkGroupStats.assets, publicPath, compilationHash, new Set());
+    Object.keys(stats.namedChunkGroups).forEach((chunkGroupName) => {
+      assets.chunks[chunkGroupName] = this.processFiles(
+        stats.namedChunkGroups[chunkGroupName].assets,
+        publicPath,
+        compilationHash,
+        new Set()
+      );
     });
 
     return assets;

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -197,21 +197,28 @@ describe('HtmlWebpackPlugin', () => {
   });
 
   it('allows you to specify your own HTML template file', done => {
-    testHtmlPlugin({
-      mode: 'production',
-      entry: {
-        app: path.join(__dirname, 'fixtures/index.js')
-      },
-      output: {
-        path: OUTPUT_DIR,
-        filename: '[name]_bundle.js'
-      },
-      plugins: [new HtmlWebpackPlugin({
-        template: path.join(__dirname, 'fixtures/test.html'),
-        inject: false
-      })]
-    },
-    ['<script src="app_bundle.js', 'Some unique text'], null, done);
+    testHtmlPlugin(
+      {
+        mode: 'production',
+        entry: {
+          app: path.join(__dirname, 'fixtures/index.js')
+        },
+        output: {
+          path: OUTPUT_DIR,
+          filename: '[name]_bundle.js'
+        },
+        plugins: [new HtmlWebpackPlugin({
+          template: path.join(__dirname, 'fixtures/test.html'),
+          inject: false
+        })]
+      }, [
+        '<script src="app_bundle.js',
+        '<link rel="preload" href="app_bundle.js" as="script"',
+        'Some unique text'
+      ],
+      null,
+      done
+    );
   });
 
   it('picks up src/index.ejs by default', done => {
@@ -441,23 +448,29 @@ describe('HtmlWebpackPlugin', () => {
   });
 
   it('should work with the css extract plugin', done => {
-    testHtmlPlugin({
-      mode: 'production',
-      entry: path.join(__dirname, 'fixtures/theme.js'),
-      output: {
-        path: OUTPUT_DIR,
-        filename: 'index_bundle.js'
-      },
-      module: {
-        rules: [
-          { test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }
+    testHtmlPlugin(
+      {
+        mode: 'production',
+        entry: path.join(__dirname, 'fixtures/theme.js'),
+        output: {
+          path: OUTPUT_DIR,
+          filename: 'index_bundle.js'
+        },
+        module: {
+          rules: [
+            { test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }
+          ]
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            template: path.join(__dirname, 'fixtures/theme.html')
+          }),
+          new MiniCssExtractPlugin({filename: 'styles.css'})
         ]
-      },
-      plugins: [
-        new HtmlWebpackPlugin(),
-        new MiniCssExtractPlugin({filename: 'styles.css'})
-      ]
-    }, ['<link href="styles.css" rel="stylesheet">'], null, done);
+      }, [
+        '<link href="styles.css" rel="stylesheet">',
+        '<link rel="preload" href="styles.css" as="style"'
+      ], null, done);
   });
 
   it('should work with the css extract plugin on windows and protocol relative urls support (#205)', done => {

--- a/spec/fixtures/test.html
+++ b/spec/fixtures/test.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8"/>
     <title>Test</title>
+
+    <link rel="preload" href="<%=htmlWebpackPlugin.files.chunks.app.js[0]%>" as="script" />
   </head>
   <body>
     <p>Some unique text</p>

--- a/spec/fixtures/theme.html
+++ b/spec/fixtures/theme.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Test</title>
+
+    <link rel="preload" href="<%=htmlWebpackPlugin.files.chunks.main.css[0]%>" as="style" />
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
This PR essentially reverts the change from 37db0868efdbf334a1b60003fe5bd376cfd8ae01 that removed `chunks` from the asset parameters. In doing so, it should resolve #1158 and #1092. My hope is that using `toJson({all: false, chunkGroups: true})` with a filter for only the info we need is enough to mitigate the performance concerns that caused it to be removed previously. I benchmarked our build (6000 modules, 27 `HtmlWebpackPlugin` instances) and saw no change in duration with this change.

My use case for this is rendering `preload` tags, grouped by chunk, into the HTML template of our single page app. Each chunk's preload tags are inside of a conditional block that gets included in the final HTML rendered by the server only if that chunk is used by the initial route. Doing this allows us to start downloading route-specific chunks immediately before the main chunk has been dowloaded and parsed.

Our template that we feed into HtmlWebpackPlugin looks like this:
```handlebars
<!DOCTYPE html>
<html>
	<head>
		<meta charset="utf-8"/>
		<title>Test</title>

		<if isTrue="{! route='one'}">
			{{#each htmlWebpackPlugin.files.chunks.one.css as |file|}}
			<link rel="preload" href="{{file}}" as="style" />
			{{/each}}
			{{#each htmlWebpackPlugin.files.chunks.one.js as |file|}}
			<link rel="preload" href="{{file}}" as="script" />
			{{/each}}
		</if>
		<if isTrue="{! route='two'}">
			{{#each htmlWebpackPlugin.files.chunks.two.css as |file|}}
			<link rel="preload" href="{{file}}" as="style" />
			{{/each}}
			{{#each htmlWebpackPlugin.files.chunks.two.js as |file|}}
			<link rel="preload" href="{{file}}" as="script" />
			{{/each}}
		</if>

		{{#each htmlWebpackPlugin.files.css as |file|}}
		<link rel="stylesheet" href="{{file}}" type="text/css" />
		{{/each}}
	</head>
	<body>
		{{#each htmlWebpackPlugin.files.css as |file|}}
		<script src="{{file}}"></script>
		{{/each}}
	</body>
</html>

```