### PR TITLE
Allow user defined tags for js injection

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,7 +238,6 @@ class HtmlWebpackPlugin {
             if (typeof(self.options.inject) == 'string') {
               scriptTarget = self.options.inject
             }
-            const scriptTarget = self.options.inject === 'head' ? 'head' : 'body';
             // Group assets to `head` and `body` tag arrays
             const assetGroups = this.generateAssetGroups(assetTags, scriptTarget);
             // Allow third-party-plugin authors to reorder and change the assetTags once they are grouped

--- a/index.js
+++ b/index.js
@@ -234,9 +234,9 @@ class HtmlWebpackPlugin {
           }))
           .then(({ assetTags }) => {
             // Inject scripts to body unless it set explictly to a user defined tag
-            let scriptTarget = 'body'
-            if (typeof(self.options.inject) == 'string') {
-              scriptTarget = self.options.inject
+            let scriptTarget = 'body';
+            if (typeof (self.options.inject) === 'string') {
+              scriptTarget = self.options.inject;
             }
             // Group assets to `head` and `body` tag arrays
             const assetGroups = this.generateAssetGroups(assetTags, scriptTarget);
@@ -828,10 +828,10 @@ class HtmlWebpackPlugin {
     // on the htmlPluginOptions
     if (scriptTarget === 'body') {
       result.bodyTags.push(...assetTags.scripts);
-    } else  if (scriptTarget == 'head') {
+    } else if (scriptTarget === 'head') {
       result.headTags.push(...assetTags.scripts);
     } else {
-       result.userDefinedTags.push(...assetTags.scripts)
+      result.userDefinedTags.push(...assetTags.scripts);
     }
     return result;
   }
@@ -854,11 +854,11 @@ class HtmlWebpackPlugin {
     const htmlRegExp = /(<html[^>]*>)/i;
     const headRegExp = /(<\/head\s*>)/i;
     const bodyRegExp = /(<\/body\s*>)/i;
-    const otherTagRegExp = new RegExp(`(<\/${this.options.inject}\\s*>)`, 'i')
+    const otherTagRegExp = new RegExp(`(<\/${this.options.inject}\\s*>)`, 'i');
 
     const body = assetTags.bodyTags.map((assetTagObject) => htmlTagObjectToString(assetTagObject, this.options.xhtml));
     const head = assetTags.headTags.map((assetTagObject) => htmlTagObjectToString(assetTagObject, this.options.xhtml));
-    const user_defined_tag = assetTags.userDefinedTags.map((assetTagObject) => htmlTagObjectToString(assetTagObject, this.options.xhtml));
+    const userDefinedTag = assetTags.userDefinedTags.map((assetTagObject) => htmlTagObjectToString(assetTagObject, this.options.xhtml));
 
     if (body.length) {
       if (bodyRegExp.test(html)) {
@@ -884,13 +884,13 @@ class HtmlWebpackPlugin {
       html = html.replace(headRegExp, match => head.join('') + match);
     }
 
-    if (user_defined_tag.length) {
-        if (otherTagRegExp.test(html)) {
+    if (userDefinedTag.length) {
+      if (otherTagRegExp.test(html)) {
         // Append assets to body element
-        html = html.replace(otherTagRegExp, match => user_defined_tag.join('') + match);
+        html = html.replace(otherTagRegExp, match => userDefinedTag.join('') + match);
       } else {
         // Append scripts to the end of the file if no <other> element exists:
-        html += user_defined_tag.join('');
+        html += userDefinedTag.join('');
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -854,7 +854,7 @@ class HtmlWebpackPlugin {
     const htmlRegExp = /(<html[^>]*>)/i;
     const headRegExp = /(<\/head\s*>)/i;
     const bodyRegExp = /(<\/body\s*>)/i;
-    const otherTagRegExp = new RegExp(`(<${this.options.inject}\\s*>)`, 'i');
+    const otherTagRegExp = new RegExp(`(<\/${this.options.inject}\\s*>)`, 'i');
 
     const body = assetTags.bodyTags.map((assetTagObject) => htmlTagObjectToString(assetTagObject, this.options.xhtml));
     const head = assetTags.headTags.map((assetTagObject) => htmlTagObjectToString(assetTagObject, this.options.xhtml));

--- a/index.js
+++ b/index.js
@@ -854,7 +854,7 @@ class HtmlWebpackPlugin {
     const htmlRegExp = /(<html[^>]*>)/i;
     const headRegExp = /(<\/head\s*>)/i;
     const bodyRegExp = /(<\/body\s*>)/i;
-    const otherTagRegExp = new RegExp(`(<\/${this.options.inject}\\s*>)`, 'i');
+    const otherTagRegExp = new RegExp(`(</${this.options.inject}\\s*>)`, 'i');
 
     const body = assetTags.bodyTags.map((assetTagObject) => htmlTagObjectToString(assetTagObject, this.options.xhtml));
     const head = assetTags.headTags.map((assetTagObject) => htmlTagObjectToString(assetTagObject, this.options.xhtml));

--- a/index.js
+++ b/index.js
@@ -854,7 +854,7 @@ class HtmlWebpackPlugin {
     const htmlRegExp = /(<html[^>]*>)/i;
     const headRegExp = /(<\/head\s*>)/i;
     const bodyRegExp = /(<\/body\s*>)/i;
-    const otherTagRegExp = new RegExp(`(<\/${this.options.inject}\\s*>)`, 'i');
+    const otherTagRegExp = new RegExp(`(<${this.options.inject}\\s*>)`, 'i');
 
     const body = assetTags.bodyTags.map((assetTagObject) => htmlTagObjectToString(assetTagObject, this.options.xhtml));
     const head = assetTags.headTags.map((assetTagObject) => htmlTagObjectToString(assetTagObject, this.options.xhtml));


### PR DESCRIPTION
Provide support for injection of JS assets into custom tags.  Currently the **html-webpack-plugin** will insert into the end of the head or body section depending upon the **inject** setting.  This PR provides support to allow a user to define a different element to insert the script tags into.

Reasoning behind this is often times template engines will build upon base templates. For instance in a django application a user often defines a base.html template that would define the entire head and body sections and then provide something like a content {% block content %}{% endblock %}.  The idea being that the user would then extend this base template into say home.html, about_us.html, etc.

The problem is that webpack sees the html before the other the django templating system (which is runtime).  It is currently possible to have webpack insert all js into the base.html template.  However, this is not desierable.  In a multiplage web application each page is likely to contain it's own JS code.  

With this pr the user can now do something like this in weback.conf


```
...
inject: webpack-inject-js
...
...
```

Then in any templates they want to inject js into they would simply add their custom tag to the end.
```
<webpack-injected-js></webpack-injected-js>
```