### PR TITLE
Fix tiny typo

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -21,7 +21,7 @@ module.exports = function (source) {
     return source;
   }
 
-  // The following part renders the template with lodash as aminimalistic loader
+  // The following part renders the template with lodash as a minimalistic loader
   //
   const template = _.template(source, _.defaults(options, { interpolate: /<%=([\s\S]+?)%>/g, variable: 'data' }));
   // Require !!lodash - using !! will disable all loaders (e.g. babel)


### PR DESCRIPTION
Hey noticed a tiny typo in the comment.
"as aminimalistic loader" => "as a minimalistic loader"