### PR TITLE
Feature/template parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,17 +371,21 @@ class HtmlWebpackPlugin {
     if (templateParameters === false) {
       return Promise.resolve({});
     }
+    const preparedAssetTags = {
+      headTags: this.prepareAssetTagGroupForRendering(assetTags.headTags),
+      bodyTags: this.prepareAssetTagGroupForRendering(assetTags.bodyTags)
+    };
     if (typeof templateParameters === 'function') {
-      const preparedAssetTags = {
-        headTags: this.prepareAssetTagGroupForRendering(assetTags.headTags),
-        bodyTags: this.prepareAssetTagGroupForRendering(assetTags.bodyTags)
-      };
       return Promise
         .resolve()
         .then(() => templateParameters(compilation, assets, preparedAssetTags, this.options));
     }
-    if (typeof templateParameters === 'object') {
-      return Promise.resolve(templateParameters);
+    if (templateParameters && typeof templateParameters === 'object') {
+      const defaultTemplateParameters = templateParametersGenerator(compilation, assets, preparedAssetTags, this.options);
+      return Promise.resolve({
+        ...defaultTemplateParameters,
+        ...templateParameters,
+      });
     }
     throw new Error('templateParameters has to be either a function or an object');
   }

--- a/index.js
+++ b/index.js
@@ -382,10 +382,7 @@ class HtmlWebpackPlugin {
     }
     if (templateParameters && typeof templateParameters === 'object') {
       const defaultTemplateParameters = templateParametersGenerator(compilation, assets, preparedAssetTags, this.options);
-      return Promise.resolve({
-        ...defaultTemplateParameters,
-        ...templateParameters
-      });
+      return Promise.resolve(Object.assign({}, defaultTemplateParameters, templateParameters));
     }
     throw new Error('templateParameters has to be either a function or an object');
   }

--- a/index.js
+++ b/index.js
@@ -384,7 +384,7 @@ class HtmlWebpackPlugin {
       const defaultTemplateParameters = templateParametersGenerator(compilation, assets, preparedAssetTags, this.options);
       return Promise.resolve({
         ...defaultTemplateParameters,
-        ...templateParameters,
+        ...templateParameters
       });
     }
     throw new Error('templateParameters has to be either a function or an object');

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -2077,7 +2077,7 @@ describe('HtmlWebpackPlugin', () => {
           templateParameters: { foo: 'bar' }
         })
       ]
-    }, ['templateParams keys: "foo"'], null, done);
+    }, ['templateParams keys: "compilation,webpackConfig,htmlWebpackPlugin,foo"'], null, done);
   });
 
   it('should allow to set specific template parameters using a function', done => {


### PR DESCRIPTION
`options.templateParameters` will override the ***default templateParameters*** when it's an object. Sometimes, I just want to set a `title` parameter. However, this will make me can not use the ***default parameter***, such as `htmlWebpackPlugin.files.js`, which is absolutely usefull when I want to custom my html.

Even though, a function type `options.templateParameters` can deal with this problem, but it's not direct or convenient.

So, I suggest to just mix `options.templateParameters` to ***default templateParameters***. This will be easier to use.

Thanks for you reviewing.