### PR TITLE
update lodash dependency for prototype polution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/node": "11.13.9",
     "@types/tapable": "1.0.4",
     "appcache-webpack-plugin": "1.4.0",
-    "commitizen": "3.1.1",
+    "commitizen": "4.0.3",
     "css-loader": "2.1.1",
     "cz-conventional-changelog": "2.1.0",
     "dir-compare": "1.7.2",
@@ -54,7 +54,7 @@
   "dependencies": {
     "html-minifier": "^4.0.0",
     "loader-utils": "^1.2.3",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "pretty-error": "^2.1.1",
     "tapable": "^1.1.3",
     "util.promisify": "1.0.0"


### PR DESCRIPTION
This pull requests updates lodash to address this vulnerability: https://npmjs.com/advisories/1065

commitizen also needed to be updated since its older version also depended on a vulnerable version of lodash.