### PR TITLE
Fix README typo

### DIFF
--- a/examples/custom-insertion-position/readme.md
+++ b/examples/custom-insertion-position/readme.md
@@ -1,7 +1,7 @@
 # custom insertion example
 
 This example shows how you can define the position where the scripts are injected
-by setting `inject:false` and using the template parameters inside the `inside.ejs`
+by setting `inject:false` and using the template parameters inside the `index.ejs`
 
 The example is using the template parameters `headTags` and `bodyTags`
 


### PR DESCRIPTION
Had "inside.ejs" instead of "index.ejs"