### PR TITLE
Charset meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,26 @@ plugins: [
 ]
 ```
 
+#### charset meta tag
+
+This meta tag is very common. Since it requires a `charset` attribute instead of the `name` and `content` attributes, it should be added using:
+
+**webpack.config.js**
+```js
+plugins: [
+  new HtmlWebpackPlugin({
+    'meta': {
+      'charset': { 'charset': 'utf-8' },
+      // Will generate: <meta charset="utf-8">
+      'foobar': { 'charset': 'utf-8' }
+      // Will generate the same meta tag as the example above!
+    }
+  })
+]
+```
+
+Be aware that the key of the attribute object has no effect on the resulting meta tag. However, it is a good practice to give it a descriptive name.
+
 #### Simulate http response headers
 
 The **http-equiv** attribute is essentially used to simulate a HTTP response header.  

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -1690,6 +1690,24 @@ describe('HtmlWebpackPlugin', () => {
     }, [/<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">/], null, done);
   });
 
+  it('adds a meta tag that specifies the charset', done => {
+    testHtmlPlugin({
+      mode: 'production',
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          meta: {
+            'charset': { 'charset': 'utf-8' }
+          }
+        })
+      ]
+    }, [/<meta charset="utf-8">/], null, done);
+  });
+
   it('adds a favicon with publicPath set to /some/', done => {
     testHtmlPlugin({
       mode: 'production',


### PR DESCRIPTION
```html
<meta charset="utf-8">
```
This meta tag is commonly used. In fact, it often appears in the HTML templates in this repository. However, the README.md hardly explains how this can be done unfortunately.
This is why I added a section to the README.md, that describes how to do it with a corresponding example and additional information.

I also added a test to `basic.spec.js` for this case, because why not (:

Cheers :v: