### PR TITLE
Add static variable `globalMeta`

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ For the default template the html-webpack-plugin will already provide a default 
 
 Please take a look at this well maintained list of almost all [possible meta tags](https://github.com/joshbuchea/HEAD#meta).
 
+
 #### name/content meta tags 
 
 Most meta tags are configured by setting a `name` and a `content` attribute.  
@@ -385,6 +386,33 @@ plugins: [
       // Will generate: <meta http-equiv="set-cookie" content="value; expires=date; path=url">
       // Which equals to the following http header: `set-cookie: value; expires=date; path=url`
     }
+  })
+]
+```
+
+#### Global meta settings
+
+If you want to generate multiple HTML files, they will most likely have similiar meta tags. In this case you can specify a static variable called `globalMeta` to set meta tags that every `HtmlWebpackPlugin` instance will take into account.
+
+**webpack.config.js**
+```js
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+// set static variable
+HtmlWebpackPlugin.globalMeta = {
+  'viewport': 'width=device-width, initial-scale=1, shrink-to-fit=no'
+}
+```
+```js
+plugins: [
+  new HtmlWebpackPlugin({
+    'filename': 'index.html',
+    'meta': { 'theme-color': '#4285f4' }
+    // Will generate 'theme-color' and the global 'viewport' meta tag
+  }),
+  new HtmlWebpackPlugin({
+    'filename': 'test.html',
+    'meta': {}
+    // Will generate the global 'viewport' meta tag
   })
 ]
 ```

--- a/index.js
+++ b/index.js
@@ -70,6 +70,9 @@ class HtmlWebpackPlugin {
       this.options.meta = Object.assign({}, this.options.meta, defaultMeta, userOptions.meta);
     }
 
+    // Apply global meta object
+    this.options.meta = Object.assign({}, this.options.meta, HtmlWebpackPlugin.globalMeta);
+
     // Instance variables to keep caching information
     // for multiple builds
     this.childCompilerHash = undefined;
@@ -1016,5 +1019,10 @@ HtmlWebpackPlugin.version = 4;
  */
 HtmlWebpackPlugin.getHooks = getHtmlWebpackPluginHooks;
 HtmlWebpackPlugin.createHtmlTagObject = createHtmlTagObject;
+
+/**
+ * Global meta object that is used for every instance
+ */
+HtmlWebpackPlugin.globalMeta = {};
 
 module.exports = HtmlWebpackPlugin;

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -1690,6 +1690,26 @@ describe('HtmlWebpackPlugin', () => {
     }, [/<meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">/], null, done);
   });
 
+  it('adds a meta tag using the static globalMeta variable', done => {
+    HtmlWebpackPlugin.globalMeta = { 'foo': 'bar' };
+    testHtmlPlugin({
+      mode: 'production',
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          meta: {}
+        })
+      ]
+    }, [/<meta name="foo" content="bar">/], null, done);
+
+    // unset for subsequent tests
+    HtmlWebpackPlugin.globalMeta = {};
+  });
+
   it('adds a favicon with publicPath set to /some/', done => {
     testHtmlPlugin({
       mode: 'production',


### PR DESCRIPTION
If you want to keep meta tags similiar across multiple HTML files, you would probably define a constant in your `webpack.config.js` and pass it to every instance - like so:
```js
const GLOBAL_META = {
  'viewport': '...',
  'theme-color': '...',
  // etc
}
...
plugins: [
  new HtmlWebpackPlugin({
    filename: 'a.html',
    template: 'src/a.html',
    meta: GLOBAL_META
  }),
  new HtmlWebpackPlugin({
    filename: 'b.html',
    template: 'src/b.html',
    meta: GLOBAL_META
  })
]
```
It is even more inconvenient if you want to overwrite these global settings for single `HtmlWebpackPlugin` instances.

This is why I introduced a static variable in the `HtmlWebpackPlugin` class called `globalMeta`. This variable is the same for all instances of `HtmlWebpackPlugin` and is applied with the instance specific `meta` option during construction.

**Example:**
```js
const HtmlWebpackPlugin = require('html-webpack-plugin');
// set static variable
HtmlWebpackPlugin.globalMeta = {
  'viewport': '...'
}
```
```js
plugins: [
  new HtmlWebpackPlugin({
    'filename': 'a.html',
    'template': 'src/a.html'
    'meta': { 'theme-color': '...' }
    // Will generate 'theme-color' and the global 'viewport' meta tag
  }),
  new HtmlWebpackPlugin({
    'filename': 'b.html',
    'template': 'src/b.html',
    'meta': {} // can be omitted, of course
    // Will generate the global 'viewport' meta tag
  })
]
```

A section in the `README.md` and a corresponding test was added to `basic.spec.js` as well.

Cheers!