### PR TITLE
docs: Add templateContent param back to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Allowed values are as follows
 |**`title`**|`{String}`|`Webpack App`|The title to use for the generated HTML document|
 |**`filename`**|`{String}`|`'index.html'`|The file to write the HTML to. Defaults to `index.html`. You can specify a subdirectory here too (eg: `assets/admin.html`)|
 |**`template`**|`{String}`|``|`webpack` relative or absolute path to the template. By default it will use `src/index.ejs` if it exists. Please see the [docs](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md) for details|
-|**[`templateContent`](#)**|`{String\|Function}`|``|A string that contains (or function that returns) the content of the template. `template` and `templateContent` options **may not both be used**. Overwrites `template` option|
+|**`templateContent`**|`{String\|Function}`|``|A string that contains (or function that returns) the content of the template. `template` and `templateContent` options **may not both be used**. Overwrites `template` option|
 |**`templateParameters`**|`{Boolean\|Object\|Function}`|``| Allows to overwrite the parameters used in the template - see [example](https://github.com/jantimon/html-webpack-plugin/tree/master/examples/template-parameters) |
 |**`inject`**|`{Boolean\|String}`|`true`|`true \|\| 'head' \|\| 'body' \|\| false` Inject all assets into the given `template` or `templateContent`. When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element - see the [inject:false example](https://github.com/jantimon/html-webpack-plugin/tree/master/examples/custom-insertion-position)|
 |**`favicon`**|`{String}`|``|Adds the given favicon path to the output HTML|

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Allowed values are as follows
 |**`title`**|`{String}`|`Webpack App`|The title to use for the generated HTML document|
 |**`filename`**|`{String}`|`'index.html'`|The file to write the HTML to. Defaults to `index.html`. You can specify a subdirectory here too (eg: `assets/admin.html`)|
 |**`template`**|`{String}`|``|`webpack` relative or absolute path to the template. By default it will use `src/index.ejs` if it exists. Please see the [docs](https://github.com/jantimon/html-webpack-plugin/blob/master/docs/template-option.md) for details|
+|**[`templateContent`](#)**|`{String\|Function}`|``|A string that contains (or function that returns) the content of the template. `template` and `templateContent` options **may not both be used**. Overwrites `template` option|
 |**`templateParameters`**|`{Boolean\|Object\|Function}`|``| Allows to overwrite the parameters used in the template - see [example](https://github.com/jantimon/html-webpack-plugin/tree/master/examples/template-parameters) |
 |**`inject`**|`{Boolean\|String}`|`true`|`true \|\| 'head' \|\| 'body' \|\| false` Inject all assets into the given `template` or `templateContent`. When passing `true` or `'body'` all javascript resources will be placed at the bottom of the body element. `'head'` will place the scripts in the head element - see the [inject:false example](https://github.com/jantimon/html-webpack-plugin/tree/master/examples/custom-insertion-position)|
 |**`favicon`**|`{String}`|``|Adds the given favicon path to the output HTML|

--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ class HtmlWebpackPlugin {
             });
           });
 
-        // Turn the compiled tempalte into a nodejs function or into a nodejs string
+        // Turn the compiled template into a nodejs function or into a nodejs string
         const templateEvaluationPromise = compilationPromise
           .then(compiledTemplate => {
             // Allow to use a custom function / string instead


### PR DESCRIPTION
This change has been made because I noticed that `templateContent` had disappeared from the docs! Looks like it was [accidentally removed here?](https://github.com/jantimon/html-webpack-plugin/commit/1b3adb1b5a9c58ac9d060068758999196fba22d8#diff-04c6e90faac2675aa89e2176d2eec7d8L126) 

This commit will add the templateContent variable back from this [previously merged PR](https://github.com/jantimon/html-webpack-plugin/pull/1024) 

Also noticed a small typo, so corrected that one too :)