### PR TITLE
Add hooks document for version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,27 @@ about which values are passed.
 Example implementation: [webpack-subresource-integrity](https://www.npmjs.com/package/webpack-subresource-integrity)
 
 **plugin.js**
+#### Version 3
+```js
+// If your plugin is direct dependent to the html webpack plugin:
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+class MyPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap('MyPlugin', (compilation) => {
+      console.log('The compiler is starting a new compilation...');
+
+      compilation.hooks.htmlWebpackPluginBeforeHtmlProcessing.tap('MyPlugin', (data) => {
+        data.html += 'The Magic Footer';
+      });
+    });
+  }
+}
+
+module.exports = MyPlugin;
+```
+
+#### Version 4+
 ```js
 // If your plugin is direct dependent to the html webpack plugin:
 const HtmlWebpackPlugin = require('html-webpack-plugin');

--- a/README.md
+++ b/README.md
@@ -533,9 +533,6 @@ Example implementation: [webpack-subresource-integrity](https://www.npmjs.com/pa
 **plugin.js**
 #### Version 3
 ```js
-// If your plugin is direct dependent to the html webpack plugin:
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-
 class MyPlugin {
   apply(compiler) {
     compiler.hooks.compilation.tap('MyPlugin', (compilation) => {


### PR DESCRIPTION
Hello. There was a confusing part about the hooks of `html-webpack-plugin`. 

The API called `getHooks` is not yet supported in v3, but It was written in the document. The current version is v3 and I think we should inform about it in the document.

## Reference
- https://github.com/jantimon/html-webpack-plugin/issues/1110