### PR TITLE
refactor: Use getAssetPath instead of calling the hook directly

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -179,7 +179,7 @@ class HtmlWebpackChildCompiler {
  */
 function extractHelperFilesFromCompilation (mainCompilation, childCompilation, filename, childEntryChunks) {
   const helperAssetNames = childEntryChunks.map((entryChunk, index) => {
-    return mainCompilation.mainTemplate.hooks.assetPath.call(filename, {
+    return mainCompilation.mainTemplate.getAssetPath(filename, {
       hash: childCompilation.hash,
       chunk: entryChunk,
       name: `HtmlWebpackPlugin_${index}`
@@ -261,7 +261,7 @@ function compileTemplate (templatePath, outputFilename, mainCompilation) {
     if (!compiledTemplates[templatePath]) console.log(Object.keys(compiledTemplates), templatePath);
     const compiledTemplate = compiledTemplates[templatePath];
     // Replace [hash] placeholders in filename
-    const outputName = mainCompilation.mainTemplate.hooks.assetPath.call(outputFilename, {
+    const outputName = mainCompilation.mainTemplate.getAssetPath(outputFilename, {
       hash: compiledTemplate.hash,
       chunk: compiledTemplate.entry
     });


### PR DESCRIPTION
Fixes #1287