### PR TITLE
Update typedefs after switch to html-minifier-terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     ]
   },
   "devDependencies": {
-    "@types/html-minifier": "3.5.3",
+    "@types/html-minifier-terser": "5.0.0",
     "@types/loader-utils": "1.1.3",
     "@types/node": "11.13.9",
     "@types/tapable": "1.0.4",

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,6 +1,6 @@
 import { AsyncSeriesWaterfallHook } from "tapable";
 import { Compiler, compilation } from 'webpack';
-import { Options as HtmlMinifierOptions } from "html-minifier";
+import { Options as HtmlMinifierOptions } from "html-minifier-terser";
 
 export = HtmlWebpackPlugin;
 


### PR DESCRIPTION
Just upgraded to 4.0.0. I had to patch the type definitions to make `tsc` happy. Seems like this got lost during the switch to `html-minifier-terser` in  c66766cdae3593091dee413b9c585359c24ef068.