### PR TITLE
fix: don't remove trailing slashes from self closing tags by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,10 +115,11 @@ class HtmlWebpackPlugin {
 
     const minify = this.options.minify;
     if (minify === true || (minify === 'auto' && isProductionLikeMode)) {
-      /** @type { import('html-minifier').Options } */
+      /** @type { import('html-minifier-terser').Options } */
       this.options.minify = {
-        // https://github.com/kangax/html-minifier#options-quick-reference
+        // https://www.npmjs.com/package/html-minifier-terser#options-quick-reference
         collapseWhitespace: true,
+        keepClosingSlash: true,
         removeComments: true,
         removeRedundantAttributes: true,
         removeScriptTypeAttributes: true,

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -2304,4 +2304,27 @@ describe('HtmlWebpackPlugin', () => {
       ]
     }, [/<script defer="defer".+<link href="styles.css"/], null, done);
   });
+
+  it('should keep closing slashes from the template', done => {
+    testHtmlPlugin({
+      mode: 'production',
+      entry: path.join(__dirname, 'fixtures/theme.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      module: {
+        rules: [
+          { test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }
+        ]
+      },
+      plugins: [
+        new HtmlWebpackPlugin({
+          scriptLoading: 'defer',
+          templateContent: '<html><body> <selfclosed /> </body></html>'
+        }),
+        new MiniCssExtractPlugin({ filename: 'styles.css' })
+      ]
+    }, [/<selfclosed\/>/], null, done);
+  });
 });


### PR DESCRIPTION
Fix for the issue https://github.com/jantimon/html-webpack-plugin/issues/1370

by default the html-minifier would turn `<demo />` into `<demo>`.

advantage: will fix problems for people using xml elements inside html (e.g. #1370)
disadvantage: if someone would add `<img .. />` it  can't be minified anymore to `<img>`.  