### PR TITLE
Typings depends on @types webpack, tapable and html-minifier-terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,8 @@
     ]
   },
   "devDependencies": {
-    "@types/html-minifier-terser": "5.0.0",
     "@types/loader-utils": "1.1.3",
     "@types/node": "11.13.9",
-    "@types/tapable": "1.0.4",
     "appcache-webpack-plugin": "1.4.0",
     "commitizen": "4.0.3",
     "css-loader": "2.1.1",
@@ -52,6 +50,9 @@
     "webpack-recompilation-simulator": "3.0.0"
   },
   "dependencies": {
+    "@types/html-minifier-terser": "^5.0.0",
+    "@types/tapable": "^1.0.5",
+    "@types/webpack": "^4.41.8",
     "html-minifier-terser": "^5.0.1",
     "loader-utils": "^1.2.3",
     "lodash": "^4.17.15",


### PR DESCRIPTION
`typings.d.ts` depends on @types/webpack, @types/tapable and @types/html-minifier-terser: https://github.com/jantimon/html-webpack-plugin/blob/v4.0.2/typings.d.ts#L1-L3

Thus they should be in dependencies instead of devDependencies like the "old" @types/html-webpack-plugin npm package: https://www.npmjs.com/package/@types/html-webpack-plugin?activeTab=dependencies
