### PR TITLE
fix: delete example Landing Page 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,8 +2,8 @@
 
 A collection of repositories or pages using html-webpack-plugin.
 
-Example | Link | Description
---- | --- | ---
+Example | Link
+--- | ---
 Appcache | [appcache](./appcache)
 Chunk Optimization | [chunk-optimization](./chunk-optimization)
 Custom Template | [custom-template](./custom-template)
@@ -17,4 +17,3 @@ Javascript | [javascript](./javascript)
 Pug Loader | [pug-loader](./pug-loader)
 Sort Manually | [sort-manually](./sort-manually)
 Template Parameters | [template-parameters](./template-parameters)
-Landing Page | [webpack-static-webpage-example](https://github.com/TroyTae/webpack-static-webpage-example) | Landing page example that is optimized SEO and performance.


### PR DESCRIPTION
Now I remaking the example for supporting multi static pages.
So I delete the example link temporarily because url is broken.
