### PR TITLE
fix: Allow to use outdated @types/webpack types

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/loader-utils": "1.1.3",
+    "@types/webpack": "~4.41.8",
     "@types/node": "11.13.9",
     "appcache-webpack-plugin": "1.4.0",
     "commitizen": "4.0.3",
@@ -52,7 +53,7 @@
   "dependencies": {
     "@types/html-minifier-terser": "^5.0.0",
     "@types/tapable": "^1.0.5",
-    "@types/webpack": "^4.41.8",
+    "@types/webpack": "~4",
     "html-minifier-terser": "^5.0.1",
     "loader-utils": "^1.2.3",
     "lodash": "^4.17.15",


### PR DESCRIPTION
If an older version of @types/webpack is installed in the same project typescript reported "TS2322:
Type 'HtmlWebpackPlugin' is not assignable to type 'Plugin'"

#1383