### PR TITLE
fix: don't add dependencies twice to the webpack 5 watcher api

### DIFF
--- a/lib/webpack5/file-watcher-api.js
+++ b/lib/webpack5/file-watcher-api.js
@@ -58,7 +58,6 @@ function isSnapShotValid (snapshot, mainCompilation) {
 function watchFiles (mainCompilation, fileDependencies) {
   Object.keys(fileDependencies).forEach((depencyTypes) => {
     fileDependencies[depencyTypes].forEach(fileDependency => {
-      mainCompilation.fileDependencies.add(fileDependency);
       mainCompilation[depencyTypes].add(fileDependency);
     });
   });


### PR DESCRIPTION
this pr fixes a bug which added dependencies multiple times
https://github.com/webpack/webpack/issues/10789

thanks @sokra 
