### PR TITLE
feat: Allow to use console.log inside templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@ class HtmlWebpackPlugin {
     // To extract the result during the evaluation this part has to be removed.
     source = source.replace('var HTML_WEBPACK_PLUGIN_RESULT =', '');
     const template = this.options.template.replace(/^.+!/, '').replace(/\?.+$/, '');
-    const vmContext = vm.createContext(_.extend({ HTML_WEBPACK_PLUGIN: true, require: require }, global));
+    const vmContext = vm.createContext(_.extend({ HTML_WEBPACK_PLUGIN: true, require: require, console: console }, global));
     const vmScript = new vm.Script(source, { filename: template });
     // Evaluate code and cast to string
     let newSource;


### PR DESCRIPTION
Allow `console.log` (or `error`, `warn`....) inside templates.

E.g.:

```js
<% console.log("Hello World") %>
```

The output will be written by webpack (so it will be visible in the terminal not in the browser console)