### PR TITLE
feat(typings.d.ts): tweak typings for webpack 5 beta

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,5 +1,5 @@
 import { AsyncSeriesWaterfallHook } from "tapable";
-import { Compiler, compilation } from 'webpack';
+import { Compiler, default as Webpack } from 'webpack';
 import { Options as HtmlMinifierOptions } from "html-minifier-terser";
 
 export = HtmlWebpackPlugin;
@@ -9,7 +9,7 @@ declare class HtmlWebpackPlugin {
 
   apply(compiler: Compiler): void;
 
-  static getHooks(compilation: compilation.Compilation): HtmlWebpackPlugin.Hooks;
+  static getHooks(compilation: Webpack.Compilation): HtmlWebpackPlugin.Hooks;
 }
 
 declare namespace HtmlWebpackPlugin {


### PR DESCRIPTION
hi~
I found a typings error when using html-webpack-plugin in webpack 5 beta.

tsc reports an error
`Module '"../../../../../../../Users/kamilic/Documents/projects/(sensitive-string)/node_modules/webpack/types"' has no exported member 'compilation'. Did you mean 'Compilation'?
`

But, i am not sure whether `Webpack.Compilation` is equals to `compilation`. 
If I am wrong please let me know and i will edit it.