### PR TITLE
added v5 compilation support and deleted depreciation warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ const getHtmlWebpackPluginHooks = require('./lib/hooks.js').getHtmlWebpackPlugin
 const fsStatAsync = promisify(fs.stat);
 const fsReadFileAsync = promisify(fs.readFile);
 
+const webpackMajorVersion = Number(require('webpack/package.json').version.split('.')[0]);
+
 class HtmlWebpackPlugin {
   /**
    * @param {HtmlWebpackOptions} [options]
@@ -149,12 +151,16 @@ class HtmlWebpackPlugin {
           compilation.errors.push(prettyError(templateResult.error, compiler.context).toString());
         }
 
-        const childCompilationOutputName = compilation.mainTemplate.getAssetPath(this.options.filename, 'compiledEntry' in templateResult ? {
+        const compiledEntries = 'compiledEntry' in templateResult ? {
           hash: templateResult.compiledEntry.hash,
           chunk: templateResult.compiledEntry.entry
         } : {
           hash: templateResult.mainCompilationHash
-        });
+        };
+
+        const childCompilationOutputName = webpackMajorVersion === 5
+          ? compilation.getAssetPath(this.options.filename, compiledEntries)
+          : compilation.mainTemplate.getAssetPath(this.options.filename, compiledEntries);
 
         // If the child compilation was not executed during a previous main compile run
         // it is a cached result
@@ -529,7 +535,10 @@ class HtmlWebpackPlugin {
      * if a path publicPath is set in the current webpack config use it otherwise
      * fallback to a realtive path
      */
-    const webpackPublicPath = compilation.mainTemplate.getPublicPath({ hash: compilationHash });
+    const webpackPublicPath = webpackMajorVersion === 5
+      ? compilation.getAssetPath(compilation.outputOptions.publicPath, { hash: compilationHash })
+      : compilation.mainTemplate.getPublicPath({ hash: compilationHash });
+
     const isPublicPathDefined = webpackPublicPath.trim() !== '';
     let publicPath = isPublicPathDefined
       // If a hard coded public path exists use it

--- a/index.js
+++ b/index.js
@@ -158,9 +158,9 @@ class HtmlWebpackPlugin {
           hash: templateResult.mainCompilationHash
         };
 
-        const childCompilationOutputName = webpackMajorVersion === 5
-          ? compilation.getAssetPath(this.options.filename, compiledEntries)
-          : compilation.mainTemplate.getAssetPath(this.options.filename, compiledEntries);
+        const childCompilationOutputName = webpackMajorVersion === 4
+          ? compilation.mainTemplate.getAssetPath(this.options.filename, compiledEntries)
+          : compilation.getAssetPath(this.options.filename, compiledEntries);
 
         // If the child compilation was not executed during a previous main compile run
         // it is a cached result
@@ -535,9 +535,9 @@ class HtmlWebpackPlugin {
      * if a path publicPath is set in the current webpack config use it otherwise
      * fallback to a realtive path
      */
-    const webpackPublicPath = webpackMajorVersion === 5
-      ? compilation.getAssetPath(compilation.outputOptions.publicPath, { hash: compilationHash })
-      : compilation.mainTemplate.getPublicPath({ hash: compilationHash });
+    const webpackPublicPath = webpackMajorVersion === 4
+      ? compilation.mainTemplate.getPublicPath({ hash: compilationHash })
+      : compilation.getAssetPath(compilation.outputOptions.publicPath, { hash: compilationHash });
 
     const isPublicPathDefined = webpackPublicPath.trim() !== '';
     let publicPath = isPublicPathDefined

--- a/lib/child-compiler.js
+++ b/lib/child-compiler.js
@@ -168,9 +168,9 @@ function extractHelperFilesFromCompilation (mainCompilation, childCompilation, f
       name: `HtmlWebpackPlugin_${index}`
     };
 
-    return webpackMajorVersion === 5
-      ? mainCompilation.getAssetPath(filename, entryConfig)
-      : mainCompilation.mainTemplate.getAssetPath(filename, entryConfig);
+    return webpackMajorVersion === 4
+      ? mainCompilation.mainTemplate.getAssetPath(filename, entryConfig)
+      : mainCompilation.getAssetPath(filename, entryConfig);
   });
 
   helperAssetNames.forEach((helperFileName) => {

--- a/lib/child-compiler.js
+++ b/lib/child-compiler.js
@@ -166,7 +166,7 @@ function extractHelperFilesFromCompilation (mainCompilation, childCompilation, f
       hash: childCompilation.hash,
       chunk: entryChunk,
       name: `HtmlWebpackPlugin_${index}`
-    }
+    };
 
     return webpackMajorVersion === 5
       ? mainCompilation.getAssetPath(filename, entryConfig)

--- a/lib/child-compiler.js
+++ b/lib/child-compiler.js
@@ -159,12 +159,18 @@ class HtmlWebpackChildCompiler {
  * @returns Array<string>
  */
 function extractHelperFilesFromCompilation (mainCompilation, childCompilation, filename, childEntryChunks) {
+  const webpackMajorVersion = Number(require('webpack/package.json').version.split('.')[0]);
+
   const helperAssetNames = childEntryChunks.map((entryChunk, index) => {
-    return mainCompilation.mainTemplate.getAssetPath(filename, {
+    const entryConfig = {
       hash: childCompilation.hash,
       chunk: entryChunk,
       name: `HtmlWebpackPlugin_${index}`
-    });
+    }
+
+    return webpackMajorVersion === 5
+      ? mainCompilation.getAssetPath(filename, entryConfig)
+      : mainCompilation.mainTemplate.getAssetPath(filename, entryConfig);
   });
 
   helperAssetNames.forEach((helperFileName) => {


### PR DESCRIPTION
#1408

What I did:
- Deleted depreciation warnings in v5 (`mainTemplate.getAssetPath`, and `getPublicPath`)
- Added backward compatibility with v4

I also consider to put this `webpackMajorVersion`, as a helper somewhere - is quite repeated few times. Feedback will be needed.