### PR TITLE
Add stacktrace to error message from childCompilation.errors

### DIFF
--- a/lib/child-compiler.js
+++ b/lib/child-compiler.js
@@ -118,7 +118,16 @@ class HtmlWebpackChildCompiler {
         }
         // Reject the promise if the childCompilation contains error
         if (childCompilation && childCompilation.errors && childCompilation.errors.length) {
-          const errorDetails = childCompilation.errors.map(error => error.message + (error.error ? ':\n' + error.error : '')).join('\n');
+          const errorDetails = childCompilation.errors.map(error => {
+            let message = error.message;
+            if (error.error) {
+              message += ':\n' + error.error;
+            }
+            if (error.stack) {
+              message += '\n' + error.stack;
+            }
+            return message;
+          }).join('\n');
           reject(new Error('Child compilation failed:\n' + errorDetails));
           return;
         }


### PR DESCRIPTION
I had an error that was thrown in my webpack.config.ts that was causing childCompilation to fail. But I didn't know it was an error thrown in my webpack.config.ts because child-compiler.js didn't include the stack trace in the error message.

The stack trace I got ended at line 122 in node_modules\html-webpack-plugin\lib\child-compiler.js. So I fiddled with that to make it output the inner error stack trace and then I got the actual place of the error.