### PR TITLE
Update index.js - added "/" to path inside generateStyleTags function

### DIFF
--- a/index.js
+++ b/index.js
@@ -705,7 +705,7 @@ class HtmlWebpackPlugin {
       tagName: 'link',
       voidTag: true,
       attributes: {
-        href: styleAsset,
+        href: "/" + styleAsset,
         rel: 'stylesheet'
       }
     }));


### PR DESCRIPTION
I had problems with css styles. I use laravel mix html template and always when pages are generated I see wrong link to css. about js/images - all fine. For example: I expect to see "/static/<filename>.css" but see "static/<filename>.css" As for js I see "/static/<filename>.js"

"static" is juts my path. Problem only with one symbol