### PR TITLE
fix: broken typings.d.ts in v4.4.0

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -18,7 +18,7 @@ declare class HtmlWebpackPlugin {
     tagName: string,
     attributes?: { [attributeName: string]: string | boolean },
     innerHTML?: string
-  ): HtmlTagObject;
+  ): HtmlWebpackPlugin.HtmlTagObject;
 
   static readonly version: number;
 }


### PR DESCRIPTION
class declaration is outside the namespace, so it needs to use it as a prefix to access its types.