### PR TITLE
What is the proper way to enable Elixir/Phoenix EEx template support?

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Allowed values are as follows
 |**`chunksSortMode`**|`{String\|Function}`|`auto`|Allows to control how chunks should be sorted before they are included to the HTML. Allowed values are `'none' \| 'auto' \| 'manual' \| {Function}`|
 |**`excludeChunks`**|`{Array.<string>}`|``|Allows you to skip some chunks (e.g don't add the unit-test chunk)|
 |**`xhtml`**|`{Boolean}`|`false`|If `true` render the `link` tags as self-closing (XHTML compliant)|
+|**`removeReplaceEex`**|`{Boolean}`|`false`|If `true` remove Elixir/Phoenix EEx tags during compilation and replace just before emission|
 
 Here's an example webpack config illustrating how to use these options
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "html-minifier-terser": "^5.0.1",
     "loader-utils": "^1.2.3",
     "lodash": "^4.17.15",
+    "pretty": "^2.0.0",
     "pretty-error": "^2.1.1",
     "tapable": "^1.1.3",
     "util.promisify": "1.0.0"

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -152,8 +152,11 @@ declare namespace HtmlWebpackPlugin {
      */
     xhtml: boolean;
     /**
-     * In addition to the options actually used by this plugin, you can use this hash to pass arbitrary data through
-     * to your template.
+     * Enforce self closing tags e.g. <link />
+     */
+    removeReplaceEEx
+    /**
+     * Remove Elixir/Phoenix EEx tags during compilation and replace just before emission
      */
     [option: string]: any;
   }


### PR DESCRIPTION
This is a draft PR for a reason, I don't expect to merge.  I just want to know what the proper way to accomplish what I've done here.  I figure someone here can give me some guidance.

I want to integrate webpack/html-webpack-plugin into my Elixir/Phoenix project.  Phoenix has it's own templating language and uses the file extension `.eex`.  It's very similar to ERB (Embedded Ruby) templates and has an almost exact similarity to `lodash` template syntax.  it uses `<%= ...%>` and `<% ... %>` markers to indicate substitution regions.  What I want is for the `html-webpack-plugin` to leave those regions unchanged during compilation (I don't currently require any webpack-template-substitutions) and to just inject the `script` and `link`/`style` tags as it normally would do otherwise.  Then when Phoenix is serving my page, it will use the latest template written from this plugin and handle the EEx template subsitutions as normal.

As it currently stands, enabling no specific loader causes a conflict with the default Lodash templating since EEx files and Lodash templates use the same syntax, so the default behavior tries to substitute for the EEx regions erroneously.  Using `raw-loader` and `html-loader` gave errors on their own which I didn't bother to track down.  Disabling the lodash templating caused an issue downstream during tag-injection (I assume the EEx substitution markers seems to cause the html parser to error out).

What I ended up doing in this PR is rewriting the file in-place at the beginning of the `apply` step so it is parseable by the lodash templater and html parser used for injection". I strip out the EEx subsitution markers and values within, and replace them with a known string, store those values and replacements in a local variable, then write the file out.  Then I allow the plugin to do it's thing. Then, just before HTML emission, I replace those stored markers so the end result is the file I wanted.  That behavior sits behind a `removeReplaceEEx` flag.

My question: Is there a more idiomatic way?  Is there a way to use webpack hooks to accomplish the same thing?  As it currently stands this update would be a fork tailored to my needs but I'd rather not fork and plug into the hooks at the webpack level or the HtmlWebpackPlugin level.  Any thoughts/advice is appreciated.