### PR TITLE
Add preserveStrings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Allowed values are as follows
 |**`chunksSortMode`**|`{String\|Function}`|`auto`|Allows to control how chunks should be sorted before they are included to the HTML. Allowed values are `'none' \| 'auto' \| 'manual' \| {Function}`|
 |**`excludeChunks`**|`{Array.<string>}`|``|Allows you to skip some chunks (e.g don't add the unit-test chunk)|
 |**`xhtml`**|`{Boolean}`|`false`|If `true` render the `link` tags as self-closing (XHTML compliant)|
+|**`preserveStrings`**|`{Boolean\|Object}`|`false`|If `true` or `{Object}` For use with frameworks like Elixir/Phoenix which have their own templating language (like EEx/ERB). This option enables preserving those templating strings while enabling html-webpack-plugin asset injection. It works by substituting a filler ("replaceWith") string for matched "preserve" regular-expressions before compilation and replacing the strings just before emission. A proxy file is generated to assist. Must be used in conjunction with "template" property.
 
 Here's an example webpack config illustrating how to use these options
 

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -238,6 +238,25 @@ describe('HtmlWebpackPlugin', () => {
     ['<script src="app_bundle.js', 'Some unique text'], null, done);
   });
 
+  it('allows you to preserve an external template file', done => {
+    testHtmlPlugin({
+      mode: 'production',
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        template: path.join(__dirname, 'fixtures/test.html'),
+        preserveStrings: true,
+        inject: false
+      })]
+    },
+    ['<!doctype html><html><head><meta charset="utf-8"/><title>Test</title></head><body><p>Some unique text</p><script src="<%=htmlWebpackPlugin.files.js[0]%>"></script></body></html>'], null, done);
+  });
+
   it('picks up src/index.ejs by default', done => {
     testHtmlPlugin({
       mode: 'production',

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -152,6 +152,16 @@ declare namespace HtmlWebpackPlugin {
      */
     xhtml: boolean;
     /**
+     * Preserve templating strings by substituting a filler string for them before compilation 
+     * and replacing the strings just before emission. Must be used in conjunction with "filename"
+     * property. When not provided: "preserve" defaults to /(<%=?[\s\S]+?%>)/g, 
+     * "proxyFilename" defaults to "__html_eex_template.html", "replaceWith" defaults to "_TEMPLATE_REPLACEMENT_"
+     */
+    preserveStrings: 
+      | true // preserve strings, use default properties
+      | false // don't do strings preservation, use default html-webpack-plugin behavior
+      | { preserve: ?(RegExp | [RegExp]), proxyFilename: ?string, replaceWith: ?string} ; // preserve template override defaults
+    /**
      * In addition to the options actually used by this plugin, you can use this hash to pass arbitrary data through
      * to your template.
      */


### PR DESCRIPTION
This PR enables `html-webpack-plugin` to be used in projects that need to emit files in simple html-like templating languages like Elixir/Phoenix's EEx templating language.  When the `preserveStrings` option is enabled, the user can provide one or an array of `preserve` regular expressions which will trigger a pre-compilation substitution with a filler string.  Just before emission, those string a replaced with the original string, thus allowing the default processor to treat the template like a normal HTML template but enabling output in the desired templating language.  This PR was motivated by the EEx templating syntax which is almost exactly similar to the syntax for Lodash templates and was causing template substitution errors when applied with `html-webpack-plugin`'s default behavior. I use this functionality by providing an `eex` template in the `template` property and giving the desired `eex` directory/filename I'd like to be output in the `filename` property.  

Any suggestions on a better approach or guidance on improvements would be appreciated.