### PR TITLE
feat: add an error if multiple incompatible webpack instance have been found

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const { createHtmlTagObject, htmlTagObjectToString, HtmlTagArray } = require('./
 
 const prettyError = require('./lib/errors.js');
 const chunkSorter = require('./lib/chunksorter.js');
+const { lookForWebpackDuplicates } = require('./lib/lookForWebpackDuplicates');
 const getHtmlWebpackPluginHooks = require('./lib/hooks.js').getHtmlWebpackPluginHooks;
 
 const fsReadFileAsync = promisify(fs.readFile);
@@ -37,6 +38,8 @@ class HtmlWebpackPlugin {
   }
 
   apply (compiler) {
+    lookForWebpackDuplicates(compiler);
+
     // Wait for configuration preset plugions to apply all configure webpack defaults
     compiler.hooks.initialize.tap('HtmlWebpackPlugin', () => {
       const userOptions = this.userOptions;

--- a/lib/lookForWebpackDuplicates.js
+++ b/lib/lookForWebpackDuplicates.js
@@ -1,0 +1,38 @@
+// @ts-check
+const webpack = require('webpack');
+const path = require('path');
+
+module.exports = {
+  /**
+   * The new Webpack 5 hook system is using a Singletons
+   * technique which relies on node require
+   *
+   * This technique breaks if multiple packages of the same name
+   * are installed as `require('packageX').hooks` would return different
+   * results
+   *
+   * This health check tries to identify this breaking change and to explain
+   * the problem to the user
+   *
+   * @param {webpack.Compiler} compiler
+   * @returns {boolean}
+   */
+  lookForWebpackDuplicates: (compiler) => {
+    // Check if compilation is using the constructor from the same package
+    // as the current compilation instance
+    if (webpack.Compiler && compiler instanceof webpack.Compiler) {
+      return false;
+    }
+    // Gather information about the relative webpack environment
+    const relativeWebpackLocation = path.dirname(
+      require.resolve('webpack/package.json')
+    );
+    const relativeWebpackVersion = require('webpack/package.json').version;
+
+    throw new Error(
+      `\nMultiple webpack versions detected!\n\nThe new Webpack 5 hook system does NOT support multiple webpack installations` +
+        `\nHtmlWebpackPlugin detected duplicated Webpack ${relativeWebpackVersion} in '${relativeWebpackLocation}'` +
+        `\nPlease check your node_modules directory for duplicatates`
+    );
+  }
+};


### PR DESCRIPTION
This pr tries to warn the user early about https://github.com/jantimon/html-webpack-plugin/issues/1535

Often this error is caused by mono repositories or by broken peer dependencies.

Some third party extensions for webpack like `cache-loader` or `webpack-dev-server` are locked to `webpack@4` peer dependency (see https://github.com/webpack/webpack-dev-server/issues/2807)