### PR TITLE
Implement entries map between entries and their output dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ The following variables are available in the template by default (you can extend
      </html>
      ```
   
-  - `htmlWebpackPlugin.files`: direct access to the files used during the compilation.
+  - `htmlWebpackPlugin.files`: direct access to the files used during the compilation. The `entries` property contains a mapping of entry names to the list of generated bundles required by that entry.
 
     ```typescript
     publicPath: string;
@@ -284,6 +284,7 @@ The following variables are available in the template by default (you can extend
     css: string[];
     manifest?: string;
     favicon?: string;
+    entries: { [entry: string]: Array<string> };
     ```
 
 
@@ -503,7 +504,8 @@ about which values are passed.
         js: Array<{string}>,
         css: Array<{string}>,
         favicon?: string | undefined,
-        manifest?: string | undefined
+        manifest?: string | undefined,
+        entries: { [entry: string]: Array<string> }
       },
       outputName: string,
       plugin: HtmlWebpackPlugin

--- a/index.js
+++ b/index.js
@@ -344,7 +344,8 @@ class HtmlWebpackPlugin {
       js: Array<string>,
       css: Array<string>,
       manifest?: string,
-      favicon?: string
+      favicon?: string,
+      entries: { [entry: string]: Array<string> }
     }} assets
    * @param {{
        headTags: HtmlTagObject[],
@@ -386,7 +387,8 @@ class HtmlWebpackPlugin {
       js: Array<string>,
       css: Array<string>,
       manifest?: string,
-      favicon?: string
+      favicon?: string,
+      entries: { [entry: string]: Array<string> }
     }} assets
    * @param {{
        headTags: HtmlTagObject[],
@@ -514,7 +516,8 @@ class HtmlWebpackPlugin {
       js: Array<string>,
       css: Array<string>,
       manifest?: string,
-      favicon?: string
+      favicon?: string,
+      entries: { [entry: string]: Array<string> }
     }} assets
    */
   isHotUpdateCompilation (assets) {
@@ -532,7 +535,8 @@ class HtmlWebpackPlugin {
       js: Array<string>,
       css: Array<string>,
       manifest?: string,
-      favicon?: string
+      favicon?: string,
+      entries: { [entry: string]: Array<string> }
     }}
    */
   htmlWebpackPluginAssets (compilation, childCompilationOutputName, entryNames, customPublicPath) {
@@ -574,7 +578,8 @@ class HtmlWebpackPlugin {
         js: Array<string>,
         css: Array<string>,
         manifest?: string,
-        favicon?: string
+        favicon?: string,
+        entries: { [entry: string]: Array<string> }
       }}
      */
     const assets = {
@@ -587,7 +592,9 @@ class HtmlWebpackPlugin {
       // Will contain the html5 appcache manifest files if it exists
       manifest: Object.keys(compilation.assets).find(assetFile => path.extname(assetFile) === '.appcache'),
       // Favicon
-      favicon: undefined
+      favicon: undefined,
+      // Will contain all entries along with their corresponding files
+      entries: {},
     };
 
     // Append a hash for cache busting
@@ -633,6 +640,10 @@ class HtmlWebpackPlugin {
         if (!extMatch) {
           return;
         }
+        if (!assets.entries[entryName]) {
+            assets.entries[entryName] = [];
+        }
+        assets.entries[entryName].push(entryPointPublicPath);
         // Skip if this file is already known
         // (e.g. because of common chunk optimizations)
         if (entryPointPublicPathMap[entryPointPublicPath]) {
@@ -1056,7 +1067,8 @@ class HtmlWebpackPlugin {
    js: Array<string>,
    css: Array<string>,
    manifest?: string,
-   favicon?: string
+   favicon?: string,
+   entries: { [entry: string]: Array<string> }
  }} assets
  * @param {{
      headTags: HtmlTagObject[],

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -140,6 +140,7 @@ declare namespace HtmlWebpackPlugin {
             css: Array<string>;
             manifest?: string;
             favicon?: string;
+            entries: { [entry: string]: Array<string> };
           },
           assetTags: {
             headTags: HtmlTagObject[];
@@ -181,6 +182,7 @@ declare namespace HtmlWebpackPlugin {
         css: Array<string>;
         manifest?: string;
         favicon?: string;
+        entries: { [entry: string]: Array<string> };
       };
       options: Options;
     };
@@ -220,6 +222,7 @@ declare namespace HtmlWebpackPlugin {
         css: Array<string>;
         favicon?: string;
         manifest?: string;
+        entries: { [entry: string]: Array<string> };
       };
       outputName: string;
       plugin: HtmlWebpackPlugin;


### PR DESCRIPTION
Fixes #1585 

Allows better generation of JSON/YAML asset manifests, by exposing each entry and it's outputs (including split chunks).

I'm not 100% sure how it would impact hooks. I can see there's one hook - the `beforeAssetTagGeneration` one - that would process the `assets` object I added the `entries` to. I guess in most cases if the plugin either mutates or does a clone and mutation, things will be fine. I can see if a hook generated it's own it would then be missing - but I don't think this is a major issue as it could be said the set of plugins in use does not support the new feature yet.

Worth noting when I reviewed this area of code, the injection code refers to the outer scope's `assets` and therefore `assets.manifest` from that outer scope, instead of the `assets` object floating through the Promise that a plugin may have replaced if it treated it as immutable. I can raise another PR to tweak but I guess means carrying through the `assets` a few stages further in the promise waterfall, as it quickly drops off and only passes through `assetTags` prior to the injection promise.