### PR TITLE
feat: omit html tag attribute with null/undefined/false value

### DIFF
--- a/lib/html-tags.js
+++ b/lib/html-tags.js
@@ -25,12 +25,14 @@ const voidTags = ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'k
  *  A tag element according to the htmlWebpackPlugin object notation
  *
  * @param xhtml {boolean}
- *   Wether the generated html should add closing slashes to be xhtml compliant
+ *   Whether the generated html should add closing slashes to be xhtml compliant
  */
 function htmlTagObjectToString (tagDefinition, xhtml) {
   const attributes = Object.keys(tagDefinition.attributes || {})
     .filter(function (attributeName) {
-      return tagDefinition.attributes[attributeName] !== false;
+      return tagDefinition.attributes[attributeName] !== false &&
+        tagDefinition.attributes[attributeName] !== null &&
+        tagDefinition.attributes[attributeName] !== undefined;
     })
     .map(function (attributeName) {
       if (tagDefinition.attributes[attributeName] === true) {
@@ -49,13 +51,13 @@ function htmlTagObjectToString (tagDefinition, xhtml) {
  * @param {string} tagName
  * the name of the tag e.g. 'div'
  *
- * @param {{[attributeName: string]: string|boolean}} [attributes]
+ * @param {Object.<string, string | boolean>} [attributes]
  * tag attributes e.g. `{ 'class': 'example', disabled: true }`
  *
  * @param {string} [innerHTML]
  *
- * @param {{[attributeName: string]: string|boolean}} [meta]
- * meta information about the tag e.g. `{ 'pluhin': 'html-webpack-plugin' }`
+ * @param {Object.<string, string | boolean>} [meta]
+ * meta information about the tag e.g. `{ 'plugin': 'html-webpack-plugin' }`
  *
  * @returns {HtmlTagObject}
  */

--- a/lib/html-tags.js
+++ b/lib/html-tags.js
@@ -30,9 +30,7 @@ const voidTags = ['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'k
 function htmlTagObjectToString (tagDefinition, xhtml) {
   const attributes = Object.keys(tagDefinition.attributes || {})
     .filter(function (attributeName) {
-      return tagDefinition.attributes[attributeName] !== false &&
-        tagDefinition.attributes[attributeName] !== null &&
-        tagDefinition.attributes[attributeName] !== undefined;
+      return tagDefinition.attributes[attributeName] === '' || tagDefinition.attributes[attributeName];
     })
     .map(function (attributeName) {
       if (tagDefinition.attributes[attributeName] === true) {

--- a/lib/html-tags.js
+++ b/lib/html-tags.js
@@ -51,12 +51,12 @@ function htmlTagObjectToString (tagDefinition, xhtml) {
  * @param {string} tagName
  * the name of the tag e.g. 'div'
  *
- * @param {Object.<string, string | boolean>} [attributes]
+ * @param {{[attributeName: string]: string|boolean|null|undefined}} [attributes]
  * tag attributes e.g. `{ 'class': 'example', disabled: true }`
  *
  * @param {string} [innerHTML]
  *
- * @param {Object.<string, string | boolean>} [meta]
+ * @param {{[attributeName: string]: string|boolean|null|undefined}} [meta]
  * meta information about the tag e.g. `{ 'plugin': 'html-webpack-plugin' }`
  *
  * @returns {HtmlTagObject}

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -1198,42 +1198,106 @@ describe('HtmlWebpackPlugin', () => {
     null, done, false, false);
   });
 
-  it('allows events to remove an attribute by setting it to null/undefined/false', done => {
-    const types = [null, undefined, false];
-
-    types.forEach(function (type) {
-      const examplePlugin = {
-        apply: function (compiler) {
-          compiler.hooks.compilation.tap('HtmlWebpackPlugin', compilation => {
-            HtmlWebpackPlugin.getHooks(compilation).alterAssetTags.tapAsync('HtmlWebpackPluginTest', (pluginArgs, callback) => {
-              pluginArgs.assetTags.scripts = pluginArgs.assetTags.scripts.map(tag => {
-                if (tag.tagName === 'script') {
-                  tag.attributes.async = type;
-                }
-                return tag;
-              });
-              callback(null, pluginArgs);
+  it('allows events to remove an attribute by setting it to false', done => {
+    const examplePlugin = {
+      apply: function (compiler) {
+        compiler.hooks.compilation.tap('HtmlWebpackPlugin', compilation => {
+          HtmlWebpackPlugin.getHooks(compilation).alterAssetTags.tapAsync('HtmlWebpackPluginTest', (pluginArgs, callback) => {
+            pluginArgs.assetTags.scripts = pluginArgs.assetTags.scripts.map(tag => {
+              if (tag.tagName === 'script') {
+                tag.attributes.async = false;
+              }
+              return tag;
             });
+            callback(null, pluginArgs);
           });
-        }
-      };
-      testHtmlPlugin({
-        mode: 'production',
-        entry: {
-          app: path.join(__dirname, 'fixtures/index.js')
-        },
-        output: {
-          path: OUTPUT_DIR,
-          filename: '[name]_bundle.js'
-        },
-        plugins: [
-          new HtmlWebpackPlugin(),
-          examplePlugin
-        ]
+        });
+      }
+    };
+    testHtmlPlugin({
+      mode: 'production',
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
       },
-      [/<script defer="defer" src="app_bundle.js"><\/script>[\s]*<\/head>/],
-      null, done, false, false);
-    });
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        examplePlugin
+      ]
+    },
+    [/<script defer="defer" src="app_bundle.js"><\/script>[\s]*<\/head>/],
+    null, done, false, false);
+  });
+
+  it('allows events to remove an attribute by setting it to null', done => {
+    const examplePlugin = {
+      apply: function (compiler) {
+        compiler.hooks.compilation.tap('HtmlWebpackPlugin', compilation => {
+          HtmlWebpackPlugin.getHooks(compilation).alterAssetTags.tapAsync('HtmlWebpackPluginTest', (pluginArgs, callback) => {
+            pluginArgs.assetTags.scripts = pluginArgs.assetTags.scripts.map(tag => {
+              if (tag.tagName === 'script') {
+                tag.attributes.async = null;
+              }
+              return tag;
+            });
+            callback(null, pluginArgs);
+          });
+        });
+      }
+    };
+    testHtmlPlugin({
+      mode: 'production',
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        examplePlugin
+      ]
+    },
+    [/<script defer="defer" src="app_bundle.js"><\/script>[\s]*<\/head>/],
+    null, done, false, false);
+  });
+
+  it('allows events to remove an attribute by setting it to undefined', done => {
+    const examplePlugin = {
+      apply: function (compiler) {
+        compiler.hooks.compilation.tap('HtmlWebpackPlugin', compilation => {
+          HtmlWebpackPlugin.getHooks(compilation).alterAssetTags.tapAsync('HtmlWebpackPluginTest', (pluginArgs, callback) => {
+            pluginArgs.assetTags.scripts = pluginArgs.assetTags.scripts.map(tag => {
+              if (tag.tagName === 'script') {
+                tag.attributes.async = undefined;
+              }
+              return tag;
+            });
+            callback(null, pluginArgs);
+          });
+        });
+      }
+    };
+    testHtmlPlugin({
+      mode: 'production',
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [
+        new HtmlWebpackPlugin(),
+        examplePlugin
+      ]
+    },
+    [/<script defer="defer" src="app_bundle.js"><\/script>[\s]*<\/head>/],
+    null, done, false, false);
   });
 
   it('provides the options to the afterEmit event', done => {

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -1198,38 +1198,42 @@ describe('HtmlWebpackPlugin', () => {
     null, done, false, false);
   });
 
-  it('allows events to remove an attribute by setting it to false', done => {
-    const examplePlugin = {
-      apply: function (compiler) {
-        compiler.hooks.compilation.tap('HtmlWebpackPlugin', compilation => {
-          HtmlWebpackPlugin.getHooks(compilation).alterAssetTags.tapAsync('HtmlWebpackPluginTest', (pluginArgs, callback) => {
-            pluginArgs.assetTags.scripts = pluginArgs.assetTags.scripts.map(tag => {
-              if (tag.tagName === 'script') {
-                tag.attributes.async = false;
-              }
-              return tag;
+  it('allows events to remove an attribute by setting it to null/undefined/false', done => {
+    const types = [null, undefined, false];
+
+    types.forEach(function (type) {
+      const examplePlugin = {
+        apply: function (compiler) {
+          compiler.hooks.compilation.tap('HtmlWebpackPlugin', compilation => {
+            HtmlWebpackPlugin.getHooks(compilation).alterAssetTags.tapAsync('HtmlWebpackPluginTest', (pluginArgs, callback) => {
+              pluginArgs.assetTags.scripts = pluginArgs.assetTags.scripts.map(tag => {
+                if (tag.tagName === 'script') {
+                  tag.attributes.async = type;
+                }
+                return tag;
+              });
+              callback(null, pluginArgs);
             });
-            callback(null, pluginArgs);
           });
-        });
-      }
-    };
-    testHtmlPlugin({
-      mode: 'production',
-      entry: {
-        app: path.join(__dirname, 'fixtures/index.js')
+        }
+      };
+      testHtmlPlugin({
+        mode: 'production',
+        entry: {
+          app: path.join(__dirname, 'fixtures/index.js')
+        },
+        output: {
+          path: OUTPUT_DIR,
+          filename: '[name]_bundle.js'
+        },
+        plugins: [
+          new HtmlWebpackPlugin(),
+          examplePlugin
+        ]
       },
-      output: {
-        path: OUTPUT_DIR,
-        filename: '[name]_bundle.js'
-      },
-      plugins: [
-        new HtmlWebpackPlugin(),
-        examplePlugin
-      ]
-    },
-    [/<script defer="defer" src="app_bundle.js"><\/script>[\s]*<\/head>/],
-    null, done, false, false);
+      [/<script defer="defer" src="app_bundle.js"><\/script>[\s]*<\/head>/],
+      null, done, false, false);
+    });
   });
 
   it('provides the options to the afterEmit event', done => {

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -263,7 +263,7 @@ declare namespace HtmlWebpackPlugin {
      * E.g. `{'disabled': true, 'value': 'demo'}`
      */
     attributes: {
-      [attributeName: string]: string | boolean;
+      [attributeName: string]: string | boolean | null | undefined;
     };
     /**
      * The tag name e.g. `'div'`


### PR DESCRIPTION
### Sumary

This `pull request` update the _html tag parsing_ to also omit attributes that contains `null` and `undefined` value.

The motivation behind this change you can find on the [Issue #1597](https://github.com/jantimon/html-webpack-plugin/issues/1597).

> PS: not sure if this is a `feat` or ` fix` 🤷‍♂️, it depends on how you see it.