### PR TITLE
hotfix: document v5.0 change to default scriptLoading

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -94,7 +94,7 @@ declare namespace HtmlWebpackPlugin {
      * blocking will result in <script src="..."></script>
      * defer will result in <script defer src="..."></script>
      *
-     * @default 'blocking'
+     * @default 'defer'
      */
     scriptLoading?: "blocking" | "defer";
     /**


### PR DESCRIPTION
The default value of the `scriptLoading` option was changed to "defer" in 35b6b87.