### PR TITLE
Fix missing loader-utils dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@types/html-minifier-terser": "^5.0.0",
     "html-minifier-terser": "^5.0.1",
+    "loader-utils": "^2.0.0",
     "lodash": "^4.17.20",
     "pretty-error": "^2.1.1",
     "tapable": "^2.0.0"


### PR DESCRIPTION
This dependency is being used in the `index.js` file.

https://github.com/jantimon/html-webpack-plugin/blob/6f39192da6d68bb58c178cc769d0c8c810bf82e7/index.js#L16-L18

https://github.com/jantimon/html-webpack-plugin/blob/6f39192da6d68bb58c178cc769d0c8c810bf82e7/index.js#L378-L380