### PR TITLE
Fix: Add `module` into the `vmContext`

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,7 @@ class HtmlWebpackPlugin {
       ...global,
       HTML_WEBPACK_PLUGIN: true,
       require: require,
+      module: module,
       htmlWebpackPluginPublicPath: publicPath,
       URL: require('url').URL,
       __filename: templateWithoutLoaders


### PR DESCRIPTION
# Problem

```
[1m[31mERROR[39m[22m in [1m  [1m[31mError[39m[22m[1m: undefined:2
  module.exports = __webpack_require__.p + "javascript,__webpack_public_path__ = __webpack_base_uri__ = htmlWebpackPluginPublicPath;.1feff74faaf0efc6a044355c92cd15d9.bin";//# sourceURL=[module]
  ^
  ReferenceError: module is not defined
  
  
  - index.html:17 Object.data:text/javascript,__webpack_public_path__ = __webpack_base_uri__ = htmlWebpackPluginPublicPath;
    /Users/ssen/Workspace/rocket-scripts/packages/.fixtures/test/fixtures/web/start-1617556766984/src/app/index.html:17:1
```

In my case, this error occurs on `html-webpack-plugin@^5`.

I solved this error by add `module` to `vmContext`. (tested with packed `.tgz` package)