### PR TITLE
feat: injection of custom root element for react/vue/angular

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,8 @@ class HtmlWebpackPlugin {
         meta: {},
         base: false,
         title: 'Webpack App',
-        xhtml: false
+        xhtml: false,
+        rootElement: false
       };
 
       /** @type {ProcessedHtmlWebpackOptions} */
@@ -80,6 +81,11 @@ class HtmlWebpackPlugin {
           viewport: 'width=device-width, initial-scale=1'
         };
         options.meta = Object.assign({}, options.meta, defaultMeta, userOptions.meta);
+      }
+
+      // Only adds the root element if it was set
+      if (options.rootElement) {
+        options.rootElement = userOptions.rootElement;
       }
 
       // entryName to fileName conversion function
@@ -298,6 +304,18 @@ function hookIntoCompiler (compiler, options, plugin) {
                 (options.inject !== 'body' && options.scriptLoading !== 'blocking') ? 'head' : 'body';
               // Group assets to `head` and `body` tag arrays
               const assetGroups = generateAssetGroups(assetTags, scriptTarget);
+
+              if (options.rootElement) {
+                assetGroups.bodyTags.push({
+                  tagName: options.rootElement.tag,
+                  voidTag: false,
+                  attributes: {
+                    id: options.rootElement.id
+                  },
+                  meta: {}
+                });
+              }
+
               // Allow third-party-plugin authors to reorder and change the assetTags once they are grouped
               return getHtmlWebpackPluginHooks(compilation).alterAssetTagGroups.promise({
                 headTags: assetGroups.headTags,

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -2799,4 +2799,23 @@ describe('HtmlWebpackPlugin', () => {
       done();
     });
   });
+  it('allows you to inject a custom root element', done => {
+    testHtmlPlugin({
+      mode: 'none',
+      entry: {
+        app: path.join(__dirname, 'fixtures/index.js')
+      },
+      output: {
+        path: OUTPUT_DIR,
+        filename: '[name]_bundle.js'
+      },
+      plugins: [new HtmlWebpackPlugin({
+        template: path.join(__dirname, 'fixtures/plain.html'),
+        rootElement: {
+          tag: 'div',
+          id: 'app'
+        }
+      })]
+    }, ['<div id="app"></div>'], null, done);
+  });
 });


### PR DESCRIPTION
I was previously using [this plugin](https://github.com/LKay/html-webpack-root-element-plugin#readme) to inject a custom div root element into the generated HTML page.

However, that plugin has not been maintained for several years and no longer works with Webpack 5. I know many others have wished for root element support in the issues, so the time felt right to stick a PR in to implement that.

Reviews/comments/thoughts/suggestions welcome.