### PR TITLE
Fix security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@types/html-minifier-terser": "^5.0.0",
     "html-minifier-terser": "^5.0.1",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "pretty-error": "^3.0.4",
     "tapable": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -29,30 +29,30 @@
   },
   "devDependencies": {
     "@types/node": "11.13.9",
-    "commitizen": "4.2.1",
+    "commitizen": "^4.2.4",
     "css-loader": "5.0.1",
     "cz-conventional-changelog": "2.1.0",
     "dir-compare": "1.7.2",
     "html-loader": "2.1.1",
     "jest": "26.5.3",
-    "mini-css-extract-plugin": "1.0.0",
+    "mini-css-extract-plugin": "^1.6.0",
     "pug": "3.0.2",
     "pug-loader": "2.4.0",
     "raw-loader": "4.0.2",
     "rimraf": "2.6.3",
     "semistandard": "^13.0.1",
-    "standard-version": "9.1.0",
+    "standard-version": "^9.3.0",
     "style-loader": "2.0.0",
     "typescript": "4.1.3",
     "webpack": "5.24.3",
-    "webpack-recompilation-simulator": "3.2.0",
-    "webpack-cli": "4.5.0"
+    "webpack-cli": "4.5.0",
+    "webpack-recompilation-simulator": "3.2.0"
   },
   "dependencies": {
     "@types/html-minifier-terser": "^5.0.0",
     "html-minifier-terser": "^5.0.1",
     "lodash": "^4.17.20",
-    "pretty-error": "^2.1.1",
+    "pretty-error": "^3.0.4",
     "tapable": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
- fix #1651 
  - update "commitizen" to "^4.2.4"
  - update "mini-css-extract-plugin" to "^1.6.0"
  - update "standard-version" to "^9.3.0"
  - update "pretty-error" to "^3.0.4"
- fix #1645 
  - update "lodash" to "^4.17.21"

Side note: `npm audit` still shows for me the vulnerability: https://npmjs.com/advisories/1753 but I did not see the import `meow`.

Thoughts?