### PR TITLE
Remove defer keyword from the script when the inject option set to 'body'

### DIFF
--- a/index.js
+++ b/index.js
@@ -741,7 +741,7 @@ function hookIntoCompiler (compiler, options, plugin) {
       voidTag: false,
       meta: { plugin: 'html-webpack-plugin' },
       attributes: {
-        defer: options.scriptLoading !== 'blocking',
+        defer: options.scriptLoading !== 'blocking' && options.inject !== 'body',
         src: scriptAsset
       }
     }));


### PR DESCRIPTION
'defer' keyword only needs to be added to the script located inside of head tag, and it is unnecessary to be added to the script located at the end of the body tag since it won't work as a block-resource anyway.
(https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript#use_async_or_defer)

It was used to be normal in html-webpack-plugin version 4.5.0 which is used in [create-react-app](https://github.com/facebook/create-react-app), but I guess it had been changed during the update.

Currently only the options.scriptLoading: 'blocking' makes defer keyword to be omitted, but this is quite non-declarative for the user. It would be better to add one more condition to make this defer keyword goes away especially when the user sets options.inject to 'body'.
