### PR TITLE
Bump pretty-error to 4.0.0 to fix transitive vuln for ansi-regex CVE-2021-3807

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/html-minifier-terser": "^6.0.0",
     "html-minifier-terser": "^6.0.2",
     "lodash": "^4.17.21",
-    "pretty-error": "^3.0.4",
+    "pretty-error": "^4.0.0",
     "tapable": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Context
* Bump pretty-error to 4.0.0 to address vuln via transitive deps: `renderkid`-> `strip-ansi` -> `ansi-regex`
* Follow up from: https://github.com/AriaMinaei/RenderKid/pull/25
* Vuln: CVE-2021-3807

## Changes
* Bump pretty-error from `^3.0.4` to `^4.0.0`

## Consequences
* Major package bump so node 4.x no longer supported

## Testing
I just ran the test suite, can maintainers do more extensive testing around the pretty errors.