### PR TITLE
docs: added html-webpack-plugin-django to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The `html-webpack-plugin` provides [hooks](https://github.com/jantimon/html-webp
   * [html-webpack-skip-assets-plugin](https://github.com/swimmadude66/html-webpack-skip-assets-plugin) Skip adding certain output files to the html file. Built as a drop-in replacement for [html-webpack-exclude-assets-plugin](https://www.npmjs.com/package/html-webpack-exclude-assets-plugin) and works with newer [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) versions
  * [html-webpack-inject-preload](https://github.com/principalstudio/html-webpack-inject-preload) allows to add preload links &lt;link rel='preload'> anywhere you want.
  * [inject-body-webpack-plugin](https://github.com/Jaid/inject-body-webpack-plugin) is a simple method of injecting a custom HTML string into the body.
+ * [html-webpack-plugin-django](https://github.com/TommasoAmici/html-webpack-plugin-django) a Webpack plugin to inject Django static tags.
 
 
 <h2 align="center">Usage</h2>


### PR DESCRIPTION
Hi, I publish a `html-webpack-plugin` to output Django static tags, and I added it to the README.

e.g.

```django
{# before #}
<script defer src="dist/js/runtime.1198543abbf33da21374.js"></script>

{# after #}
<script defer src="{% static 'dist/js/runtime.1198543abbf33da21374.js' %}"></script>
```