### PR TITLE
Add missing "none" value to chunksSortMode type

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -53,6 +53,7 @@ declare namespace HtmlWebpackPlugin {
     chunksSortMode?:
       | "auto"
       | "manual"
+      | "none"
       | ((entryNameA: string, entryNameB: string) => number);
     /**
      * List all entries which should not be injected


### PR DESCRIPTION
According to README (and ChunkSorter implementation) "none" value should be allowed as a `chunksSortMode` option, but TypeScript typings doesn't allow it.