### PR TITLE
feat: add js-entry-webpack-plugin to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The `html-webpack-plugin` provides [hooks](https://github.com/jantimon/html-webp
  * [html-webpack-inject-preload](https://github.com/principalstudio/html-webpack-inject-preload) allows to add preload links &lt;link rel='preload'> anywhere you want.
  * [inject-body-webpack-plugin](https://github.com/Jaid/inject-body-webpack-plugin) is a simple method of injecting a custom HTML string into the body.
  * [html-webpack-plugin-django](https://github.com/TommasoAmici/html-webpack-plugin-django) a Webpack plugin to inject Django static tags.
+ * [js-entry-webpack-plugin](https://github.com/liam61/html-webpack-plugin) creates webpack bundles into your js entry
 
 
 <h2 align="center">Usage</h2>


### PR DESCRIPTION
Hi, this PR is mainly to solve the problem when choosing `js file` as project entry especially in a `Micro Frontend Project`

And the source code is inspired by `html-webpack-plugin`

Usage: 

```js
import JSEntryWebpackPlugin from 'js-entry-webpack-plugin'

module.exports = {
  entry: 'index.js',
  output: {
    path: __dirname + '/dist',
  },
  plugins: [new JSEntryWebpackPlugin()],
}
```

Thanks for checking, if possible, add it on the awesome list which can be convenient for others

Related Issue: #1699 