### PR TITLE
Update version of html-minifier-terser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@types/html-minifier-terser": "^6.0.0",
-    "html-minifier-terser": "^6.0.2",
+    "html-minifier-terser": "^7.0.0",
     "lodash": "^4.17.21",
     "pretty-error": "^4.0.0",
     "tapable": "^2.0.0"


### PR DESCRIPTION
Current version of html-minifier-terser depends on outdated version of terser vulnerable to ReDOS.
html-minifier-terser@7.0.0 depends on terser ^5.14.2, which addresses the vulnerability.