### PR TITLE
fix: add support for __dirname in JavaScript bundle

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,8 @@ class HtmlWebpackPlugin {
       require: require,
       htmlWebpackPluginPublicPath: publicPath,
       URL: require('url').URL,
-      __filename: templateWithoutLoaders
+      __filename: templateWithoutLoaders,
+      __dirname: path.dirname(templateWithoutLoaders)
     });
     const vmScript = new vm.Script(source, { filename: templateWithoutLoaders });
     // Evaluate code and cast to string

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -2813,4 +2813,32 @@ describe('HtmlWebpackPlugin', () => {
       done();
     });
   });
+
+  it('allows __dirname and __filename in requireExtensions', done => {
+    testHtmlPlugin({
+      mode: 'production',
+      entry: path.join(__dirname, 'fixtures/index.js'),
+      output: {
+        path: OUTPUT_DIR,
+        filename: 'index_bundle.js'
+      },
+      plugins: [
+        {
+          apply (compiler) {
+            compiler.hooks.compilation.tap(
+              'some-require-hook-plugin',
+              (compilation) => {
+                compilation.mainTemplate.hooks.requireExtensions.tap(
+                  'some-require-hook',
+                  (source, chunk) => {
+                    return `const something = __dirname + __filename;`;
+                  }
+                );
+              }
+            );
+          }
+        },
+        new HtmlWebpackPlugin()]
+    }, [/<script defer="defer" src="index_bundle.js"><\/script>[\s]*<\/head>/], null, done);
+  });
 });


### PR DESCRIPTION
This PR adds support for `__dirname` in the JS bundle. A previous PR implementing this was closed due to inactivity - this PR picks up that work to see if we can get it over the finish line.

Supersedes #1650
Fixes https://github.com/jantimon/html-webpack-plugin/issues/1649