### PR TITLE
Process named chunks instead of entry points

### DIFF
--- a/lib/chunksorter.js
+++ b/lib/chunksorter.js
@@ -3,7 +3,7 @@
 'use strict';
 
 /**
- * @type {{[sortmode: string] : (entryPointNames: Array<string>, compilation, htmlWebpackPluginOptions) => Array<string> }}
+ * @type {{[sortmode: string] : (chunkNames: Array<string>, compilation, htmlWebpackPluginOptions) => Array<string> }}
  * This file contains different sort methods for the entry chunks names
  */
 module.exports = {};
@@ -17,20 +17,20 @@ module.exports.none = chunks => chunks;
 
 /**
  * Sort manually by the chunks
- * @param  {string[]} entryPointNames the chunks to sort
+ * @param  {string[]} chunkNames the chunks to sort
  * @param  {WebpackCompilation} compilation the webpack compilation
  * @param  htmlWebpackPluginOptions the plugin options
  * @return {string[]} The sorted chunks
  */
-module.exports.manual = (entryPointNames, compilation, htmlWebpackPluginOptions) => {
+module.exports.manual = (chunkNames, compilation, htmlWebpackPluginOptions) => {
   const chunks = htmlWebpackPluginOptions.chunks;
   if (!Array.isArray(chunks)) {
-    return entryPointNames;
+    return chunkNames;
   }
   // Remove none existing entries from
   // htmlWebpackPluginOptions.chunks
-  return chunks.filter((entryPointName) => {
-    return compilation.entrypoints.has(entryPointName);
+  return chunks.filter((chunkName) => {
+    return compilation.namedChunks.has(chunkName);
   });
 };
 


### PR DESCRIPTION
This PR refactors the plugin so that all named chunks are sorted, not just specific entry points. So far as I can tell everything else works the same. This addresses the limitation described [here](https://github.com/jantimon/html-webpack-plugin/issues/1750#issuecomment-1344724958)