### PR TITLE
fix: compatibility with ES modules output

### DIFF
--- a/examples/default/dist/webpack-5/bundle.js
+++ b/examples/default/dist/webpack-5/bundle.js
@@ -6,7 +6,7 @@
 
 "use strict";
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "Z": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */   Z: () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
 /* harmony import */ var _node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(609);
 /* harmony import */ var _node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0__);
@@ -117,7 +117,7 @@ var update = _node_modules_style_loader_dist_runtime_injectStylesIntoStyleTag_js
 
 
 
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (_node_modules_css_loader_dist_cjs_js_main_css__WEBPACK_IMPORTED_MODULE_1__/* ["default"].locals */ .Z.locals || {});
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (_node_modules_css_loader_dist_cjs_js_main_css__WEBPACK_IMPORTED_MODULE_1__/* ["default"] */ .Z.locals || {});
 
 /***/ }),
 

--- a/examples/multi-page/dist/webpack-5/first.js
+++ b/examples/multi-page/dist/webpack-5/first.js
@@ -6,7 +6,7 @@
 
 "use strict";
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "Z": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */   Z: () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
 /* harmony import */ var _node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(609);
 /* harmony import */ var _node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0__);
@@ -117,7 +117,7 @@ var update = _node_modules_style_loader_dist_runtime_injectStylesIntoStyleTag_js
 
 
 
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (_node_modules_css_loader_dist_cjs_js_main_css__WEBPACK_IMPORTED_MODULE_1__/* ["default"].locals */ .Z.locals || {});
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (_node_modules_css_loader_dist_cjs_js_main_css__WEBPACK_IMPORTED_MODULE_1__/* ["default"] */ .Z.locals || {});
 
 /***/ }),
 

--- a/examples/multi-page/dist/webpack-5/second.js
+++ b/examples/multi-page/dist/webpack-5/second.js
@@ -6,7 +6,7 @@
 
 "use strict";
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "Z": () => (__WEBPACK_DEFAULT_EXPORT__)
+/* harmony export */   Z: () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
 /* harmony import */ var _node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(609);
 /* harmony import */ var _node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_node_modules_css_loader_dist_runtime_api_js__WEBPACK_IMPORTED_MODULE_0__);
@@ -117,7 +117,7 @@ var update = _node_modules_style_loader_dist_runtime_injectStylesIntoStyleTag_js
 
 
 
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (_node_modules_css_loader_dist_cjs_js_main_css__WEBPACK_IMPORTED_MODULE_1__/* ["default"].locals */ .Z.locals || {});
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (_node_modules_css_loader_dist_cjs_js_main_css__WEBPACK_IMPORTED_MODULE_1__/* ["default"] */ .Z.locals || {});
 
 /***/ }),
 

--- a/lib/child-compiler.js
+++ b/lib/child-compiler.js
@@ -3,6 +3,7 @@
 /** @typedef {import("webpack/lib/Compiler.js")} WebpackCompiler */
 /** @typedef {import("webpack/lib/Chunk.js")} WebpackChunk */
 'use strict';
+
 /**
  * @file
  * This file uses webpack to compile a template with a child compiler.
@@ -10,7 +11,6 @@
  * [TEMPLATE] -> [JAVASCRIPT]
  *
  */
-'use strict';
 
 let instanceId = 0;
 /**

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -23,16 +23,16 @@ module.exports = function (source) {
   }
 
   // Skip .js files (unless it's explicitly enforced)
-  if (/\.js$/.test(this.resourcePath) && !force) {
+  if (/\.(c|m)?js$/.test(this.resourcePath) && !force) {
     return source;
   }
 
   // The following part renders the template with lodash as a minimalistic loader
   //
   const template = _.template(source, { interpolate: /<%=([\s\S]+?)%>/g, variable: 'data', ...options });
-  // Use __non_webpack_require__ to enforce using the native nodejs require
+  // Use `eval("require")("lodash")` to enforce using the native nodejs require
   // during template execution
-  return 'var _ = __non_webpack_require__(' + JSON.stringify(require.resolve('lodash')) + ');' +
+  return 'var _ = eval("require")(' + JSON.stringify(require.resolve('lodash')) + ');' +
     'module.exports = function (templateParams) { with(templateParams) {' +
       // Execute the lodash template
       'return (' + template.source + ')();' +

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "standard-version": "^9.3.0",
     "style-loader": "2.0.0",
     "typescript": "4.9.4",
-    "webpack": "^5.79.0",
+    "webpack": "^5.86.0",
     "webpack-cli": "4.5.0",
     "webpack-recompilation-simulator": "3.2.0"
   },


### PR DESCRIPTION
We can't use `__non_webpack_require__`, becaue it generates `import` for ESM, use old workaround to prevent analize by webpack, anyway in future we should avoid using lodash at all and provide an options to inject this for developers