### PR TITLE
feat: add @rspack/core as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,16 @@
     "tapable": "^2.0.0"
   },
   "peerDependencies": {
+    "@rspack/core": "0.x || 1.x",
     "webpack": "^5.20.0"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
+    "webpack": {
+      "optional": true
+    }
   },
   "keywords": [
     "webpack",


### PR DESCRIPTION
## Background

[Rspack](https://github.com/web-infra-dev/rspack) is a fast Rust-based web bundler and it is compatible with the architecture and ecosystem of webpack.

The `html-webpack-plugin` can be used with Rspack, but users will get a peer dependency warning:

```bash
 WARN  Issues with peer dependencies found
.
 └─┬ html-webpack-plugin 5.5.3
    └── ✕ missing peer webpack@^5.20.0
```

## Description

This PR adds `@rspack/core` as an optional peer dependency, and make webpack as an optional peer dependency too.

## Related issues

- https://github.com/web-infra-dev/rspack/issues/4537
- https://github.com/webpack/webpack-dev-server/issues/4776