### PR TITLE
Avoid using unique ID in child compiler template path

### DIFF
--- a/lib/child-compiler.js
+++ b/lib/child-compiler.js
@@ -13,7 +13,6 @@
 /** @typedef {import("webpack").sources.Source} Source */
 /** @typedef {{hash: string, entry: Chunk, content: string, assets: {[name: string]: { source: Source, info: import("webpack").AssetInfo }}}} ChildCompilationTemplateResult */
 
-let instanceId = 0;
 /**
  * The HtmlWebpackChildCompiler is a helper to allow reusing one childCompiler
  * for multiple HtmlWebpackPlugin instances to improve the compilation performance.
@@ -24,8 +23,6 @@ class HtmlWebpackChildCompiler {
    * @param {string[]} templates
    */
   constructor (templates) {
-    /** Id for this ChildCompiler */
-    this.id = instanceId++;
     /**
      * @type {string[]} templateIds
      * The template array will allow us to keep track which input generated which output
@@ -110,12 +107,12 @@ class HtmlWebpackChildCompiler {
     childCompiler.context = mainCompilation.compiler.context;
 
     // Generate output file names
-    const temporaryTemplateNames = this.templates.map((template, index) => `__child-HtmlWebpackPlugin_${index}-${this.id}`);
+    const temporaryTemplateNames = this.templates.map((template, index) => `__child-HtmlWebpackPlugin_${index}-${template}`);
 
     // Add all templates
     this.templates.forEach((template, index) => {
-      new EntryPlugin(childCompiler.context, 'data:text/javascript,__webpack_public_path__ = __webpack_base_uri__ = htmlWebpackPluginPublicPath;', `HtmlWebpackPlugin_${index}-${this.id}`).apply(childCompiler);
-      new EntryPlugin(childCompiler.context, template, `HtmlWebpackPlugin_${index}-${this.id}`).apply(childCompiler);
+      new EntryPlugin(childCompiler.context, 'data:text/javascript,__webpack_public_path__ = __webpack_base_uri__ = htmlWebpackPluginPublicPath;', `HtmlWebpackPlugin_${index}-${template}`).apply(childCompiler);
+      new EntryPlugin(childCompiler.context, template, `HtmlWebpackPlugin_${index}-${template}`).apply(childCompiler);
     });
 
     // The templates are compiled and executed by NodeJS - similar to server side rendering


### PR DESCRIPTION
## What problem does this solve?

Unique child compiler IDs cause a memory leak in watch mode

Resolves https://github.com/jantimon/html-webpack-plugin/issues/1835

## Details

This change reverts https://github.com/jantimon/html-webpack-plugin/commit/aa64b824606896ed01daf7e6da80429785ecd7bc, which introduced a change where each child compiler is given a unique ID. This causes duplicate source strings to be cached on every recompile, without removing the old sources.

More details and screenshots in the issue linked above. The main thing I'm unclear about is why unique IDs were used in the first place, but as far as I can tell the ID isn't referenced anywhere else. Let me know if I've missed something!

## Testing done

- [x] Unit tests pass
- [x] Tested locally, the memory leak is resolved when using `template` instead of the unique ID