### PR TITLE
fix: avoid importing all of lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const promisify = require("util").promisify;
 
 const vm = require("vm");
 const fs = require("fs");
-const _ = require("lodash");
+const _uniq = require("lodash/uniq");
 const path = require("path");
 const { CachedChildCompilation } = require("./lib/cached-child-compiler");
 
@@ -990,7 +990,7 @@ class HtmlWebpackPlugin {
    * @private
    */
   getAssetFiles(assets) {
-    const files = _.uniq(
+    const files = _uniq(
       Object.keys(assets)
         .filter((assetType) => assetType !== "chunks" && assets[assetType])
         .reduce((files, assetType) => files.concat(assets[assetType]), []),

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,7 +1,7 @@
 /* This loader renders the template with underscore if no other loader was found */
 // @ts-nocheck
 "use strict";
-const _ = require("lodash");
+const _template = require("lodash/template");
 
 module.exports = function (source) {
   // Get templating options
@@ -34,7 +34,7 @@ module.exports = function (source) {
 
   // The following part renders the template with lodash as a minimalistic loader
   //
-  const template = _.template(source, {
+  const template = _template(source, {
     interpolate: /<%=([\s\S]+?)%>/g,
     variable: "data",
     ...options,

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -9,7 +9,7 @@ const path = require("path");
 const fs = require("fs");
 const webpack = require("webpack");
 const rimraf = require("rimraf");
-const _ = require("lodash");
+const _extend = require("lodash/extend");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const webpackMajorVersion = Number(
   require("webpack/package.json").version.split(".")[0],
@@ -2167,7 +2167,7 @@ describe("HtmlWebpackPlugin", () => {
             compilation,
           ).beforeEmit.tapAsync("HtmlWebpackPluginTest", (object, callback) => {
             eventFiredForFirstPlugin = true;
-            const result = _.extend(object, {
+            const result = _extend(object, {
               html: object.html + "Injected by first plugin",
             });
             callback(null, result);
@@ -2224,7 +2224,7 @@ describe("HtmlWebpackPlugin", () => {
             compilation,
           ).beforeEmit.tapAsync("HtmlWebpackPluginTest", (object, callback) => {
             eventFiredForFirstPlugin = true;
-            const result = _.extend(object, {
+            const result = _extend(object, {
               html: object.html + "Injected by first plugin",
             });
             callback(null, result);
@@ -2239,7 +2239,7 @@ describe("HtmlWebpackPlugin", () => {
             compilation,
           ).beforeEmit.tapAsync("HtmlWebpackPluginTest", (object, callback) => {
             eventFiredForSecondPlugin = true;
-            const result = _.extend(object, {
+            const result = _extend(object, {
               html: object.html + " Injected by second plugin",
             });
             callback(null, result);


### PR DESCRIPTION
This PR reduces bundle size and makes it more resilient to use in monorepo setups using nx or yarn workspaces.

This specific error is fixed:
```
TypeError: _.uniq is not a function
    at HtmlWebpackPlugin.getAssetFiles (/app/node_modules/html-webpack-plugin/index.js:738:21)
    at HtmlWebpackPlugin.generateHTML (/app/node_modules/html-webpack-plugin/index.js:1025:46)
    at /app/node_modules/html-webpack-plugin/index.js:174:22
    at fn (/app/node_modules/webpack/lib/Compilation.js:510:9)
    at _next2 (eval at create (/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:16:1)
    at eval (eval at create (/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:39:1)
    at eval (eval at create (/app/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:11:1)
```

<img width="752" alt="Bildschirmfoto 2024-07-11 um 10 48 16" src="https://github.com/jantimon/html-webpack-plugin/assets/32421538/8350e3e0-f2bc-4d0e-a1ae-9f3d9255f867">
