### PR TITLE
fix: handle `childCompilation.errors` being an iterator rather than array

### DIFF
--- a/lib/child-compiler.js
+++ b/lib/child-compiler.js
@@ -198,15 +198,15 @@ class HtmlWebpackChildCompiler {
           childCompilation.errors &&
           childCompilation.errors.length
         ) {
-          const errorDetails = childCompilation.errors
-            .map((error) => {
-              let message = error.message;
-              if (error.stack) {
-                message += "\n" + error.stack;
-              }
-              return message;
-            })
-            .join("\n");
+          const errorDetailsArray = [];
+          for (const error of childCompilation.errors) {
+            let message = error.message;
+            if (error.stack) {
+              message += "\n" + error.stack;
+            }
+            errorDetailsArray.push(message);
+          }
+          const errorDetails = errorDetailsArray.join("\n");
 
           reject(new Error("Child compilation failed:\n" + errorDetails));
 


### PR DESCRIPTION
fixes https://github.com/jantimon/html-webpack-plugin/pull/1847/
fixes https://github.com/jantimon/html-webpack-plugin/issues/1846