### PR TITLE
fix: compilation.errors should contain Error objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -1307,7 +1307,9 @@ class HtmlWebpackPlugin {
 
     if ("error" in templateResult) {
       compilation.errors.push(
-        prettyError(templateResult.error, compiler.context).toString(),
+        new Error(
+          prettyError(templateResult.error, compiler.context).toString(),
+        ),
       );
     }
 
@@ -1497,7 +1499,9 @@ class HtmlWebpackPlugin {
       .catch((err) => {
         // In case anything went wrong the promise is resolved
         // with the error message and an error is logged
-        compilation.errors.push(prettyError(err, compiler.context).toString());
+        compilation.errors.push(
+          new Error(prettyError(err, compiler.context).toString()),
+        );
         return this.options.showErrors
           ? prettyError(err, compiler.context).toHtml()
           : "ERROR";


### PR DESCRIPTION
We ran into an issue where HtmlWebpackPlugin where Rspack would crash with an error

```
/node_modules/@rspack/core/dist/index.js:1370
            push: (...newItems)=>(adm.spliceWithArray(adm.length, 0, newItems), adm.length),
                                      ^

Error: Missing field name
    at Proxy.push (/node_modules/@rspack/core/dist/index.js:1370:39)
```

I tracked it down to some [rust code](https://github.com/web-infra-dev/rspack/blob/19b2442c1bd6efcb712bae2c479cb6260fec4aa9/crates/rspack_binding_api/src/error.rs#L204) in Rspack. My fix in this PR is to just wrap the pretty-error string in an `Error` which would also be more accurate based on both the webpack/Rspack types.

An alternative I considered was just not adding the raw error to `compilation.errors`. Would that be preferred?

Thanks!
