### PR TITLE
fix: provide module/exports in VM sandbox for Node.js 25+ compatibility

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -28,7 +28,8 @@
     "specialattribute",
     "dircompare",
     "wagoid",
-    "autocrlf"
+    "autocrlf",
+    "Rspack"
   ],
   "ignorePaths": [
     "CHANGELOG.md",

--- a/index.js
+++ b/index.js
@@ -640,11 +640,17 @@ class HtmlWebpackPlugin {
     delete globalClone.eval;
     delete globalClone.Function;
     // Not using `...global` as it throws when localStorage is not explicitly enabled in Node 25+
+    // Provide a CommonJS-style `module`/`exports` pair so templates compiled as CommonJS
+    // (e.g. Rspack's child compilation output, which wraps the result in `module.exports = ...`)
+    // can assign to them instead of failing with `module is not defined`.
+    const sandboxModule = { exports: {} };
     const vmContext = vm.createContext(
       Object.assign(globalClone, {
         HTML_WEBPACK_PLUGIN: true,
         // Copying nonstandard globals like `require` explicitly as they may be absent from `global`
         require: require,
+        module: sandboxModule,
+        exports: sandboxModule.exports,
         htmlWebpackPluginPublicPath: publicPath,
         __filename: templateWithoutLoaders,
         __dirname: path.dirname(templateWithoutLoaders),

--- a/spec/basic.spec.js
+++ b/spec/basic.spec.js
@@ -3853,4 +3853,16 @@ describe("HtmlWebpackPlugin", () => {
       done,
     );
   });
+
+  describe("evaluateCompilationResult", () => {
+    it("evaluates templates wrapped in a CommonJS `module.exports = ...` expression", () => {
+      const plugin = new HtmlWebpackPlugin();
+      const source = 'module.exports = "<!DOCTYPE html><title>ok</title>";';
+      return plugin
+        .evaluateCompilationResult(source, "", "template.js")
+        .then((result) => {
+          expect(result).toBe("<!DOCTYPE html><title>ok</title>");
+        });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Templates whose child compilation output is a CommonJS module — for example,
HtmlWebpackPlugin's child compilation under **Rspack** — fail at evaluation time
with `ReferenceError: module is not defined` under **Node.js 25+**.

The VM sandbox built in `evaluateCompilationResult` (reshaped in #1880 to work
around a `localStorage` regression in Node.js 25.2) no longer exposes
`module`/`exports`. Any source that assigns to `module.exports = ...` now throws.

This PR adds a throwaway `module = { exports: {} }` pair (plus `exports`) to the
sandbox so CommonJS-wrapped sources evaluate without relying on Node populating
them.

## Reproduction

With a Docusaurus 3.10 site using `future.faster: true` (Rspack) under Node 25.9.0:

```
Html Webpack Plugin:
Error: module is not defined
  - dev.html.template.ejs:1 eval
  - dev.html.template.ejs:5 ...html-webpack-plugin@5.6.6/.../lib/loader.js!.../dev.html.template.ejs
  - node:vm:149 Script.runInContext
  - index.js:663 HtmlWebpackPlugin.evaluateCompilationResult
```

Both `docusaurus build` and `docusaurus start` fail.

## Root cause

The child compilation emitted for the template under Rspack is a regular
CommonJS module that looks roughly like:

```js
module.exports = "<!DOCTYPE html>…";
```

`runInContext` executes it against the sandbox built in
[`evaluateCompilationResult`][evaluate], which since #1880 only exposes the
cloned globals plus `require`, `HTML_WEBPACK_PLUGIN`,
`htmlWebpackPluginPublicPath`, `__filename`, and `__dirname`. With neither
`module` nor `exports` present, the assignment throws before the string can be
returned.

Under Webpack 5 the child compilation output tends not to reference
`module.exports` directly, which is why this did not surface there.

[evaluate]: https://github.com/jantimon/html-webpack-plugin/blob/main/index.js#L618-L682

## Fix

Expose a local `{ exports: {} }` container as `module` (and a mirror as
`exports`) in the sandbox. Nothing in the plugin reads from them — they only
exist so a CommonJS-wrapped result can evaluate without throwing:

```diff
+ const sandboxModule = { exports: {} };
  const vmContext = vm.createContext(
    Object.assign(globalClone, {
      HTML_WEBPACK_PLUGIN: true,
      require: require,
+     module: sandboxModule,
+     exports: sandboxModule.exports,
      ...
    }),
  );
```

This mirrors what a normal Node module boundary would provide, without pulling
anything else into the sandbox.

## Tests

Added a focused unit test in `spec/basic.spec.js` that calls
`evaluateCompilationResult` with a `module.exports = "…"` source and asserts
the string result.

Verified locally on **Node 25.9.0** (macOS):

- `npm run test:only` — **161/161 passed** (includes new test)
- `npm run lint` — clean (added `Rspack` to `.cspell.json` for the new code comment)

End-to-end: patching `node_modules/html-webpack-plugin` inside a Docusaurus
3.10 project with `future.faster: true`: `docusaurus start` and `docusaurus build`
both succeed.

## Related

- #1880 — moved off `...global` for the Node 25 `localStorage` regression.
  Docusaurus author @slorber flagged "Docusaurus dev server still won't start"
  in that thread; this PR addresses the Rspack side of that symptom.
- facebook/docusaurus#11545 — downstream issue, currently worked around with
  `NODE_OPTIONS=--no-webstorage`.
- Earlier #1634 proposed adding `module` too but was closed because that
  reporter's root cause was a `file-loader` misconfiguration — this PR's root
  cause is different (Rspack's CommonJS-wrapped child compilation output).